### PR TITLE
Handle all Google Speech options

### DIFF
--- a/client/brain.py
+++ b/client/brain.py
@@ -42,7 +42,7 @@ class Brain(object):
         modules.sort(key=lambda mod: mod.PRIORITY if hasattr(mod, 'PRIORITY') else 0, reverse=True)
         return modules
 
-    def query(self, text):
+    def query(self, texts):
         """
         Passes user input to the appropriate module, testing it against
         each candidate module's isValid function.
@@ -51,13 +51,14 @@ class Brain(object):
         text -- user input, typically speech, to be parsed by a module
         """
         for module in self.modules:
-            if module.isValid(text):
+            for text in texts:
 
-                try:
-                    module.handle(text, self.mic, self.profile)
-                    break
-                except:
-                    self._logger.error('Failed to execute module', exc_info=True)
-                    self.mic.say(
-                        "I'm sorry. I had some trouble with that operation. Please try again later.")
-                    break
+                if module.isValid(text):
+                    try:
+                        module.handle(text, self.mic, self.profile)
+                        return
+                    except:
+                        self._logger.error('Failed to execute module', exc_info=True)
+                        self.mic.say(
+                            "I'm sorry. I had some trouble with that operation. Please try again later.")
+                        return

--- a/client/conversation.py
+++ b/client/conversation.py
@@ -14,28 +14,29 @@ class Conversation(object):
         self.brain = Brain(mic, profile)
         self.notifier = Notifier(profile)
 
-    def delegateInput(self, text):
+    def delegateInput(self, texts):
         """A wrapper for querying brain."""
 
         # check if input is meant to start the music module
-        if any(x in text.upper() for x in ["SPOTIFY", "MUSIC"]):
-            # check if mpd client is running
-            try:
-                client = MPDClient()
-                client.timeout = None
-                client.idletimeout = None
-                client.connect("localhost", 6600)
-            except:
-                self.mic.say(
-                    "I'm sorry. It seems that Spotify is not enabled. Please read the documentation to learn how to configure Spotify.")
+        for text in texts:
+            if any(x in text.upper() for x in ["SPOTIFY", "MUSIC"]):
+                # check if mpd client is running
+                try:
+                    client = MPDClient()
+                    client.timeout = None
+                    client.idletimeout = None
+                    client.connect("localhost", 6600)
+                except:
+                    self.mic.say(
+                        "I'm sorry. It seems that Spotify is not enabled. Please read the documentation to learn how to configure Spotify.")
+                    return
+
+                self.mic.say("Please give me a moment, I'm loading your Spotify playlists.")
+                music_mode = MusicMode(self.persona, self.mic)
+                music_mode.handleForever()
                 return
 
-            self.mic.say("Please give me a moment, I'm loading your Spotify playlists.")
-            music_mode = MusicMode(self.persona, self.mic)
-            music_mode.handleForever()
-            return
-
-        self.brain.query(text)
+        self.brain.query(texts)
 
     def handleForever(self):
         """Delegates user input to the handling function when activated."""
@@ -50,7 +51,7 @@ class Conversation(object):
             if not transcribed or not threshold:
                 continue
 
-            input = self.mic.activeListen(threshold)
+            input = self.mic.activeListenToAllOptions(threshold)
             if input:
                 self.delegateInput(input)
             else:

--- a/client/mic.py
+++ b/client/mic.py
@@ -172,6 +172,19 @@ class Mic:
     def activeListen(self, THRESHOLD=None, LISTEN=True, MUSIC=False):
         """
             Records until a second of silence or times out after 12 seconds
+
+            Returns the first matching string or None
+        """
+
+        options = self.activeListenToAllOptions(THRESHOLD, LISTEN, MUSIC)
+        if options:
+            return options[0]
+
+    def activeListenToAllOptions(self, THRESHOLD=None, LISTEN=True, MUSIC=False):
+        """
+            Records until a second of silence or times out after 12 seconds
+
+            Returns a list of the matching options or None
         """
 
         AUDIO_FILE = "active.wav"

--- a/client/stt.py
+++ b/client/stt.py
@@ -79,7 +79,7 @@ class PocketSphinxSTT(object):
         print "JASPER: " + result[0]
         print "==================="
 
-        return result[0]
+        return [result[0]]
 
 """
 Speech-To-Text implementation which relies on the Google Speech API.
@@ -138,14 +138,18 @@ class GoogleSTT(object):
             response = self.http.post(url, data=data, headers=headers)
             response.encoding = 'utf-8'
             response_read = response.text
-            decoded = json.loads(response_read.split("\n")[1])
 
-            text = decoded['result'][0]['alternative'][0]['transcript']
-            if text:
-                print "==================="
-                print "JASPER: " + text
-                print "==================="
-            return text
+            response_parts = response_read.strip().split("\n")
+            decoded = json.loads(response_parts[-1])
+            if decoded['result']:
+                texts = [alt['transcript'] for alt in decoded['result'][0]['alternative']]
+                if texts:
+                    print "==================="
+                    print "JASPER: " + ', '.join(texts)
+                    print "==================="
+                return texts
+            else:
+                return []
         except Exception:
             traceback.print_exc()
 

--- a/client/test.py
+++ b/client/test.py
@@ -222,7 +222,7 @@ class TestBrain(unittest.TestCase):
         hn = filter(lambda m: m.__name__ == hn_module, my_brain.modules)[0]
 
         with patch.object(hn, 'handle') as mocked_handle:
-            my_brain.query("hacker news")
+            my_brain.query(["hacker news"])
             self.assertTrue(mocked_handle.called)
 
 


### PR DESCRIPTION
Google Speech API returns multiple options for the recognition of the audio file sent. Jasper was taking just the first option, and discarding all others.

With this change all options are checked against the modules, so that if Google got it wrong with the first option, but another one was the correct one, it uses it.

I added a new method on the Mic interface, but kept he activeListen one for compatibility (which discards other options, as before).
