### PR TITLE
Use tempfile module in g2p

### DIFF
--- a/client/g2p.py
+++ b/client/g2p.py
@@ -43,9 +43,8 @@ def translateFile(input_filename, output_filename=None):
     if output_filename:
         out = '\n'.join(out)
 
-        f = open(output_filename, "wb")
-        f.write(out)
-        f.close()
+        with open(output_filename, "wb") as f:
+            f.write(out)
 
         return None
 


### PR DESCRIPTION
This is really a small PR.
- use the `tempfile` module instead of a hardcoded temporary file in the main jasper directory.
- use `with` statement instead of `f = open(...) ... f.close()`
