### PR TITLE
Remove general try except block

### DIFF
--- a/client/conversation.py
+++ b/client/conversation.py
@@ -46,14 +46,12 @@ class Conversation(object):
             for notif in notifications:
                 print notif
 
-            try:
-                threshold, transcribed = self.mic.passiveListen(self.persona)
-            except:
+            threshold, transcribed = self.mic.passiveListen(self.persona)
+            if not transcribed or not threshold:
                 continue
 
-            if threshold:
-                input = self.mic.activeListen(threshold)
-                if input:
-                    self.delegateInput(input)
-                else:
-                    self.mic.say("Pardon?")
+            input = self.mic.activeListen(threshold)
+            if input:
+                self.delegateInput(input)
+            else:
+                self.mic.say("Pardon?")

--- a/client/mic.py
+++ b/client/mic.py
@@ -138,7 +138,7 @@ class Mic:
         # no use continuing if no flag raised
         if not didDetect:
             print "No disturbance detected"
-            return
+            return (None, None)
 
         # cutoff any recording before this disturbance was detected
         frames = frames[-20:]


### PR DESCRIPTION
The `try: ... except: ...` block in conversation is really annoying, because it makes it (almost) impossible to exit jasper with a keyboard interrupt during a passiveListen phase.
I removed it and fixed the problem in `mic.py` (varying numbers of return values).

If there's any other exception raised in `passiveListen`, it should not be ignored silently.
