### PR TITLE
Remove packages from requirements.txt that seem to be unused

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,17 +1,12 @@
 APScheduler==2.1.2
 PyYAML==3.10
-Pykka==1.2.0
 argparse==1.2.1
 beautifulsoup4==4.2.1
 facebook-sdk==0.4.0
 feedparser==5.1.3
 mock==1.0.1
-numpy==1.8.0
 python-dateutil==2.1
 python-mpd==0.3.0
 pytz==2013b
-quantities==0.10.1
 semantic==1.0.3
-six==1.6.1
-ws4py==0.3.2
 requests==2.1.0


### PR DESCRIPTION
As a first step towards closing #191, I checked the requirements file for unused packages and removed them.

The packages in question are:
- Pykka
- numpy
- quantities
- six
- ws4py
