### PR TITLE
Close audio stream

### DIFF
--- a/client/mic.py
+++ b/client/mic.py
@@ -142,6 +142,9 @@ class Mic:
         # no use continuing if no flag raised
         if not didDetect:
             print "No disturbance detected"
+            stream.stop_stream()
+            stream.close()
+            audio.terminate()
             return (None, None)
 
         # cutoff any recording before this disturbance was detected


### PR DESCRIPTION
This closes the audio stream in `fetchThreshold()` and `passiveListen()` and thus fixes #33. I really hope we can tidy up `mic.py` a bit in the future, but this should do it for the moment.
