### PR TITLE
Fixed a typo in the case of multiple emails from a single sender

### DIFF
--- a/client/modules/Gmail.py
+++ b/client/modules/Gmail.py
@@ -122,7 +122,7 @@ def handle(text, mic, profile):
             response += ". Senders include: "
             response += '...'.join(senders)
         else:
-            response += " from " + unittest[0]
+            response += " from " + unique_senders[0]
 
         mic.say(response)
 


### PR DESCRIPTION
This is a very small bug I noticed when reading the source code. 
