### PR TITLE
Remove transcription mode

### DIFF
--- a/client/mic.py
+++ b/client/mic.py
@@ -9,7 +9,6 @@ import audioop
 import pyaudio
 import alteration
 import jasperpath
-from stt import TranscriptionMode
 
 
 class Mic:
@@ -172,8 +171,7 @@ class Mic:
             wav_fp.close()
             f.seek(0)
             # check if PERSONA was said
-            transcribed = self.passive_stt_engine.transcribe(
-                f, mode=TranscriptionMode.KEYWORD)
+            transcribed = self.passive_stt_engine.transcribe(f)
 
         if any(PERSONA in phrase for phrase in transcribed):
             return (THRESHOLD, PERSONA)
@@ -250,10 +248,7 @@ class Mic:
             wav_fp.writeframes(''.join(frames))
             wav_fp.close()
             f.seek(0)
-            mode = (TranscriptionMode.MUSIC if MUSIC
-                    else TranscriptionMode.NORMAL)
-            transcribed = self.active_stt_engine.transcribe(f, mode=mode)
-        return transcribed
+            return self.active_stt_engine.transcribe(f)
 
     def say(self, phrase,
             OPTIONS=" -vdefault+m3 -p 40 -s 160 --stdout > say.wav"):

--- a/client/modules/MPDControl.py
+++ b/client/modules/MPDControl.py
@@ -3,9 +3,6 @@ import re
 import logging
 import difflib
 import mpd
-import stt
-import vocabcompiler
-import jasperpath
 from mic import Mic
 
 # Standard module stuff
@@ -78,17 +75,11 @@ class MusicMode(object):
                    "PLAYLIST"]
         phrases.extend(self.music.get_soup_playlist())
 
-        vocabulary_music = vocabcompiler.PocketsphinxVocabulary(
-            name='music', path=jasperpath.config('vocabularies'))
-        vocabulary_music.compile(phrases)
-
-        # create a new mic with the new music models
-        config = stt.PocketSphinxSTT.get_config()
+        music_stt_engine = mic.active_stt_engine.get_instance('music', phrases)
 
         self.mic = Mic(mic.speaker,
                        mic.passive_stt_engine,
-                       stt.PocketSphinxSTT(vocabulary_music=vocabulary_music,
-                                           **config))
+                       music_stt_engine)
 
     def delegateInput(self, input):
 

--- a/client/test.py
+++ b/client/test.py
@@ -17,7 +17,6 @@ import brain
 import jasperpath
 import tts
 import diagnose
-from stt import TranscriptionMode
 
 DEFAULT_PROFILE = {
     'prefers_email': False,
@@ -154,22 +153,22 @@ class TestPatchedPocketsphinxVocabulary(TestPocketsphinxVocabulary):
                       self).testVocabulary()
 
 
-class TestMic(unittest.TestCase):
+class TestSTT(unittest.TestCase):
 
     def setUp(self):
         self.jasper_clip = jasperpath.data('audio', 'jasper.wav')
         self.time_clip = jasperpath.data('audio', 'time.wav')
 
         from stt import PocketSphinxSTT
-        self.stt = PocketSphinxSTT(**PocketSphinxSTT.get_config())
+        self.passive_stt_engine = PocketSphinxSTT.get_passive_instance()
+        self.active_stt_engine = PocketSphinxSTT.get_active_instance()
 
     def testTranscribeJasper(self):
         """
         Does Jasper recognize his name (i.e., passive listen)?
         """
         with open(self.jasper_clip, mode="rb") as f:
-            transcription = self.stt.transcribe(f,
-                                                mode=TranscriptionMode.KEYWORD)
+            transcription = self.passive_stt_engine.transcribe(f)
         self.assertIn("JASPER", transcription)
 
     def testTranscribe(self):
@@ -177,7 +176,7 @@ class TestMic(unittest.TestCase):
         Does Jasper recognize 'time' (i.e., active listen)?
         """
         with open(self.time_clip, mode="rb") as f:
-            transcription = self.stt.transcribe(f)
+            transcription = self.active_stt_engine.transcribe(f)
         self.assertIn("TIME", transcription)
 
 
@@ -411,7 +410,7 @@ if __name__ == '__main__':
     else:
         test_cases.append(TestG2P)
         test_cases.append(TestPocketsphinxVocabulary)
-        test_cases.append(TestMic)
+        test_cases.append(TestSTT)
 
     suite = unittest.TestSuite()
 

--- a/jasper.py
+++ b/jasper.py
@@ -80,16 +80,12 @@ class Jasper(object):
             raise
 
         try:
-            api_key = self.config['keys']['GOOGLE_SPEECH']
+            stt_engine_slug = self.config['stt_engine']
         except KeyError:
-            api_key = None
-
-        try:
-            stt_engine_type = self.config['stt_engine']
-        except KeyError:
-            stt_engine_type = "sphinx"
-            self._logger.warning("stt_engine not specified in profile, " +
-                                 "defaulting to '%s'", stt_engine_type)
+            stt_engine_slug = 'sphinx'
+            logger.warning("stt_engine not specified in profile, defaulting " +
+                           "to '%s'", stt_engine_slug)
+        stt_engine_class = stt.get_engine_by_slug(stt_engine_slug)
 
         try:
             tts_engine_slug = self.config['tts_engine']
@@ -101,8 +97,8 @@ class Jasper(object):
 
         # Initialize Mic
         self.mic = Mic(tts_engine_class.get_instance(),
-                       stt.PocketSphinxSTT(**stt.PocketSphinxSTT.get_config()),
-                       stt.newSTTEngine(stt_engine_type, api_key=api_key))
+                       stt_engine_class.get_passive_instance(),
+                       stt_engine_class.get_active_instance())
 
     def run(self):
         if 'first_name' in self.config:


### PR DESCRIPTION
If you look at `jasper.py` and `client/mic.py`, we're using the `Mic` class like this:

``` Python
class Mic:
    def__init__(self, speaker, passive_stt_engine, active_stt_engine):
```

So we pass in two different STT Engine instances:
1. An STT Engine instance for passive listen
2. An STT  Engine Instance for active listen

But PocketsphinxSTT takes up to 3 lm/dict pairs:
1. A pair for passive listen
2. A pair for active listen
3 A pair for active listen (musicmode)

This is a lot duplication, because in `jasper.py`, we're creating two separate SST Engine Instances for active listen and passive listen, so that the active listen STT Engine instance will only use the second lm/dict pair and the passive listen STT instance will only use the  first pair.
In MusicMode, a third STT instance will be created that only uses the third pair.

Given the case that someone wants to write a new module that also has the ability to start a mode like the MusicMode, he'd either have to hijack the music lm/dict pair, or he'd need to add a new mode to STT Engines and change the PocketsphinxSTTEngine code.

Thus, I'd like to simplify the STT engine dramatically by removing two of the three dict pairs (or rather Vocabulary Instances) from the PocketsphinxSTT engine and the `mode` parameter in `transcribe` accordingly.

Also, there's no need to case about custom engine-specific settings, because the `get_engine()` classmethod takes care of that for you.

This vastly simplifies how STT engines are instantiated. Basically, you only need these steps:

``` Python
import stt

engine = stt.get_engine_by_slug('sphinx')
# Alternative
engine = stt.get_engine_by_slug('google')

# Convenience method: Instance for passive listen
stt_instance_passive = engine.get_passive_instance() 
# Convenience method: Instance for active listen
stt_instance_active = engine.get_active_instance()

# Generic method (e.g. used by MusicMode (MPDControl.py)
stt_instance_custom = engine.get_instance('my_vocab', ['SOME', 'PHRASES', 'TO', 'RECOGNIZE'])

# Now create a mic:
mic1 = Mic(tts_instance, stt_instance_passive, stt_instance_active)

# A module like musicmode now can simply do this:
mic2 = Mic(mic1.speaker, mic.passive_stt_engine, stt_instance_custom)
```

So what happens inside `get_instance()` (which is also called by the convenience methods `get_passive_instance()`/`get_active_instance()`)?
- the configuration for this STT engine is retrieved
- if this STT engine needs a vocabulary ('sphinx' does, but 'google' does not):
  - a vocabulary will be initialized with the name `my_vocab`.
  - if this vocabulary does not exist yet or if it doesn't match all phrases, it'll be (re)compiled
- an STT engine instance is created with config (and vocabulary if neccessary) and returned

Because every STT engine only has one vocabulary, the `transcribe()` method becomes less complex, because it doesn't need the `mode` argument anymore.
