### PR TITLE
Fix keyword detection regression in Mic.passiveListen()

### DIFF
--- a/client/mic.py
+++ b/client/mic.py
@@ -175,7 +175,7 @@ class Mic:
             transcribed = self.passive_stt_engine.transcribe(
                 f, mode=TranscriptionMode.KEYWORD)
 
-        if PERSONA in transcribed:
+        if any(PERSONA in phrase for phrase in transcribed):
             return (THRESHOLD, PERSONA)
 
         return (False, transcribed)


### PR DESCRIPTION
This is a one-line bugfix PR.

Prior to commit 6bb87e20423e41f1bb79e6af285fe4d49cf1359a (Handle all Google Speech options, Pull Request #148), passive listen checked if the transcribed phrase contained the keyword. Since then, it only detects if the transcribed phrase was _exactly_ the keyword. When using Pocketsphinx, it often happens that additional words are transcribed (like `JASPER OF`), so that saying the keyword sometimes did not result in an active listen call. With this commmit, this regression will be fixed and the old behaviour is restored.
