### PR TITLE
Remove hardcoded ALSA device from client/tts.py

### DIFF
--- a/client/tts.py
+++ b/client/tts.py
@@ -48,7 +48,7 @@ class AbstractTTSEngine(object):
     def play(self, filename):
         # FIXME: Use platform-independent audio-output here
         # See issue jasperproject/jasper-client#188
-        cmd = ['aplay', '-D', 'hw:1,0', str(filename)]
+        cmd = ['aplay', str(filename)]
         self._logger.debug('Executing %s', ' '.join([pipes.quote(arg)
                                                      for arg in cmd]))
         with tempfile.TemporaryFile() as f:


### PR DESCRIPTION
By hardcoding the device, we're forcing users to break their audio setups in order to use jasper. Instead, users should use `~/.asoundrc` to configure ALSA so that `arecord`/`aplay` work without arguments.

This is a partial fix for issue jasperproject/jasper-client#188
