### PR TITLE
Added audioengine to make soundcards configurable and improved Mic.py.

### DIFF
--- a/client/audioengine.py
+++ b/client/audioengine.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8-*-
 import logging
 import contextlib
-import tempfile
-import subprocess
 import re
 import wave
 import pyaudio

--- a/client/audioengine.py
+++ b/client/audioengine.py
@@ -49,6 +49,38 @@ class PyAudioEngine(object):
         return [PyAudioDevice(self, self._pyaudio.get_device_info_by_index(i))
                 for i in range(num_devices)]
 
+    def get_default_input_device(self):
+        try:
+            info = self._pyaudio.get_default_input_device_info()
+        except IOError:
+            devices = self.get_input_devices()
+            if len(devices) == 0:
+                self._logger.warning('No input devices available!')
+                raise DeviceNotFound('No input devices available!')
+            try:
+                device = [d for d in devices if d.slug == 'default'][0]
+            except IndexError:
+                device = devices[0]
+            return device
+        else:
+            return PyAudioDevice(self, info)
+
+    def get_default_output_device(self):
+        try:
+            info = self._pyaudio.get_default_output_device_info()
+        except IOError:
+            devices = self.get_output_devices()
+            if len(devices) == 0:
+                self._logger.warning('No input devices available!')
+                raise DeviceNotFound('No input devices available!')
+            try:
+                device = [d for d in devices if d.slug == 'default'][0]
+            except IndexError:
+                device = devices[0]
+            return device
+        else:
+            return PyAudioDevice(self, info)
+
     def get_input_devices(self):
         return [device for device in self.get_devices()
                 if device.is_input_device]

--- a/client/audioengine.py
+++ b/client/audioengine.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8-*-
+import logging
+import contextlib
+import tempfile
+import subprocess
+import re
+import wave
+import pyaudio
+import slugify
+
+
+class UnsupportedFormat(Exception):
+    pass
+
+
+class DeviceNotFound(Exception):
+    pass
+
+
+class PyAudioEngine(object):
+    _PYAUDIO_BIT_MAPPING = {8:  pyaudio.paInt8,
+                            16: pyaudio.paInt16,
+                            24: pyaudio.paInt24,
+                            32: pyaudio.paInt32}
+
+    @classmethod
+    def _pyaudio_fmt(cls, bits):
+        if bits in cls._PYAUDIO_BIT_MAPPING.keys():
+            return cls._PYAUDIO_BIT_MAPPING[bits]
+
+    def __init__(self):
+        self._logger = logging.getLogger(__name__)
+        self._logger.info("Initializing PyAudio. ALSA/Jack error messages " +
+                          "that pop up during this process are normal and " +
+                          "can usually be safely ignored.")
+        self._pyaudio = pyaudio.PyAudio()
+        self._logger.info("Initialization of PyAudio engine finished")
+
+    def __del__(self):
+        self._pyaudio.terminate()
+
+    def get_devices(self):
+        num_devices = self._pyaudio.get_device_count()
+        self._logger.debug('Found %d PyAudio devices', num_devices)
+        return [PyAudioDevice(self, self._pyaudio.get_device_info_by_index(i))
+                for i in range(num_devices)]
+
+    def get_input_devices(self):
+        return [device for device in self.get_devices()
+                if device.is_input_device]
+
+    def get_output_devices(self):
+        return [device for device in self.get_devices()
+                if device.is_output_device]
+
+    def get_device_by_slug(self, slug):
+        for device in self. get_devices():
+            if device.slug == slug:
+                return device
+        raise DeviceNotFound("Audio device with slug '%s' not found" % slug)
+
+
+class PyAudioDevice(object):
+    RE_PRESLUG = re.compile(r'\(hw:\d,\d\)')
+
+    def __init__(self, engine, info):
+        self._logger = logging.getLogger(__name__)
+        self._engine = engine
+        self._index = info['index']
+        self._name = info['name']
+        self._max_output_channels = info['maxOutputChannels']
+        self._max_input_channels = info['maxInputChannels']
+        # slugify the name
+        preslug_name = self.RE_PRESLUG.sub('', info['name'])
+        if preslug_name.endswith(': - '):
+            preslug_name = info['name']
+        self._slug = slugify.slugify(preslug_name)
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def slug(self):
+        return self._slug
+
+    @property
+    def index(self):
+        return self._index
+
+    @property
+    def is_output_device(self):
+        return self._max_output_channels > 0
+
+    @property
+    def is_input_device(self):
+        return self._max_input_channels > 0
+
+    def supports_input_format(self, bits, channels, rate):
+        if not self.is_input_device:
+            return False
+        sample_fmt = self._engine._pyaudio_fmt(bits)
+        if not sample_fmt:
+            return False
+        return self._engine._pyaudio.is_format_supported(
+            input_device=self.index,
+            input_format=sample_fmt,
+            input_channels=channels,
+            rate=rate)
+
+    def supports_output_format(self, bits, channels, rate):
+        if not self.is_output_device:
+            return False
+        sample_fmt = self._engine._pyaudio_fmt(bits)
+        if not sample_fmt:
+            return False
+        return self._engine._pyaudio.is_format_supported(
+            output_device=self.index,
+            output_format=sample_fmt,
+            output_channels=channels,
+            rate=rate)
+
+    @contextlib.contextmanager
+    def _open_stream(self, bits, channels, rate, output=True):
+        # Check if format is supported
+        unsupported_fmt = ((output and not
+                            self.supports_output_format(bits, channels, rate))
+                           or
+                           (not output and not
+                            self.supports_input_format(bits, channels, rate)))
+        if unsupported_fmt:
+            if output:
+                msg_fmt = ("PyAudioDevice {index} ({name}) doesn't support " +
+                           "output format (Int{bits}, {channels}-channel at" +
+                           " {rate} Hz)")
+            else:
+                msg_fmt = ("PyAudioDevice {index} ({name}) doesn't support " +
+                           "input format (Int{bits}, {channels}-channel at" +
+                           " {rate} Hz)")
+            msg = msg_fmt.format(index=self.index,
+                                 name=self.name,
+                                 bits=bits,
+                                 channels=channels,
+                                 rate=rate)
+            self._logger.critical(msg)
+            raise UnsupportedFormat(msg)
+        # Everything looks fine, open the stream
+        stream = self._engine._pyaudio.open(
+            format=self._engine._pyaudio_fmt(bits),
+            channels=channels,
+            rate=rate,
+            output=output,
+            input=not output)
+        self._logger.debug("PyAudio stream opened")
+        try:
+            yield stream
+        finally:
+            stream.close()
+            self._logger.debug("PyAudio stream closed")
+
+    def record(self, chunksize, *args):
+        with self._open_stream(*args, output=False) as stream:
+            while True:
+                frame = stream.read(chunksize)
+                yield frame
+
+    def play_fp(self, fp):
+        w = wave.open(fp, 'rb')
+        channels = w.getnchannels()
+        bits = w.getsampwidth()*8
+        rate = w.getframerate()
+        with self._open_stream(bits, channels, rate) as stream:
+            stream.write(w.readframes(w.getnframes()))
+        w.close()
+
+    def play_file(self, filename):
+        with open(filename, 'rb') as f:
+            self.play_fp(f)
+        return
+        # FIXME: Use platform-independent audio-output here
+        # See issue jasperproject/jasper-client#188
+        cmd = ['aplay', str(filename)]
+        self._logger.debug('Executing %r', cmd)
+        with tempfile.TemporaryFile() as f:
+            subprocess.call(cmd, stdout=f, stderr=f)
+            f.seek(0)
+            output = f.read()
+            if output:
+                self._logger.debug("Output was: '%s'", output)
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    audioengine = PyAudioEngine()
+    devices = audioengine.get_devices()
+    slug_length = max([len(device.slug) for device in devices])
+    name_length = max([len(device.name) for device in devices])
+    fmt = ('{{index: >2}} {{slug: <{0}}} {{name: <{1}}} {{output: <3}} ' +
+           '{{input: <3}}').format(slug_length, name_length)
+    print(fmt.format(index="ID", slug="SLUG", name="NAME", output="OUT",
+                     input="IN"))
+    for device in devices:
+        print(fmt.format(index=device.index, name=device.name,
+                         slug=device.slug,
+                         output="yes" if device.is_output_device else "no",
+                         input="yes" if device.is_input_device else "no"))

--- a/client/audioengine.py
+++ b/client/audioengine.py
@@ -9,11 +9,15 @@ import pyaudio
 import slugify
 
 
-class UnsupportedFormat(Exception):
+class DeviceException(Exception):
     pass
 
 
-class DeviceNotFound(Exception):
+class UnsupportedFormat(DeviceException):
+    pass
+
+
+class DeviceNotFound(DeviceException):
     pass
 
 

--- a/client/audioengine.py
+++ b/client/audioengine.py
@@ -184,7 +184,8 @@ class PyAudioDevice(object):
             channels=channels,
             rate=rate,
             output=output,
-            input=not output)
+            input=not output,
+            frames_per_buffer=1024 if output else 8192)
         self._logger.debug("%s stream opened on device '%s' (%d Hz, %d " +
                            "channel, %d bit)", "output" if output else "input",
                            self.slug, rate, channels, bits)

--- a/client/audioengine.py
+++ b/client/audioengine.py
@@ -187,12 +187,15 @@ class PyAudioDevice(object):
             rate=rate,
             output=output,
             input=not output)
-        self._logger.debug("PyAudio stream opened")
+        self._logger.debug("%s stream opened on device '%s' (%d Hz, %d " +
+                           "channel, %d bit)", "output" if output else "input",
+                           self.slug, rate, channels, bits)
         try:
             yield stream
         finally:
             stream.close()
-            self._logger.debug("PyAudio stream closed")
+            self._logger.debug("%s stream closed on device '%s'",
+                               "output" if output else "input", self.slug)
 
     def record(self, chunksize, *args):
         with self._open_stream(*args, output=False) as stream:

--- a/client/audioengine.py
+++ b/client/audioengine.py
@@ -212,17 +212,6 @@ class PyAudioDevice(object):
     def play_file(self, filename):
         with open(filename, 'rb') as f:
             self.play_fp(f)
-        return
-        # FIXME: Use platform-independent audio-output here
-        # See issue jasperproject/jasper-client#188
-        cmd = ['aplay', str(filename)]
-        self._logger.debug('Executing %r', cmd)
-        with tempfile.TemporaryFile() as f:
-            subprocess.call(cmd, stdout=f, stderr=f)
-            f.seek(0)
-            output = f.read()
-            if output:
-                self._logger.debug("Output was: '%s'", output)
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)

--- a/client/conversation.py
+++ b/client/conversation.py
@@ -26,22 +26,7 @@ class Conversation(object):
             for notif in notifications:
                 self._logger.info("Received notification: '%s'", str(notif))
 
-            self._logger.debug("Started listening for keyword '%s'",
-                               self.persona)
-            threshold, transcribed = self.mic.passiveListen(self.persona)
-            self._logger.debug("Stopped listening for keyword '%s'",
-                               self.persona)
-
-            if not transcribed or not threshold:
-                self._logger.info("Nothing has been said or transcribed.")
-                continue
-            self._logger.info("Keyword '%s' has been said!", self.persona)
-
-            self._logger.debug("Started to listen actively with threshold: %r",
-                               threshold)
-            input = self.mic.activeListenToAllOptions(threshold)
-            self._logger.debug("Stopped to listen actively with threshold: %r",
-                               threshold)
+            input = self.mic.listen()
 
             if input:
                 self.brain.query(input)

--- a/client/local_mic.py
+++ b/client/local_mic.py
@@ -9,21 +9,13 @@ implementation, Jasper is always active listening with local_mic.
 class Mic:
     prev = None
 
-    def __init__(self, speaker, passive_stt_engine, active_stt_engine):
+    def __init__(self, *args, **kwargs):
         return
 
-    def passiveListen(self, PERSONA):
-        return True, "JASPER"
+    def wait_for_keyword(self, keyword="JASPER"):
+        return
 
-    def activeListenToAllOptions(self, THRESHOLD=None, LISTEN=True,
-                                 MUSIC=False):
-        return [self.activeListen(THRESHOLD=THRESHOLD, LISTEN=LISTEN,
-                                  MUSIC=MUSIC)]
-
-    def activeListen(self, THRESHOLD=None, LISTEN=True, MUSIC=False):
-        if not LISTEN:
-            return self.prev
-
+    def active_listen(self, timeout=3):
         input = raw_input("YOU: ")
         self.prev = input
         return input

--- a/client/modules/HN.py
+++ b/client/modules/HN.py
@@ -123,7 +123,7 @@ def handle(text, mic, profile):
         mic.say("Here are some front-page articles. " +
                 all_titles + ". Would you like me to send you these? " +
                 "If so, which?")
-        handleResponse(mic.activeListen())
+        handleResponse(mic.active_listen()[0])
 
     else:
         mic.say("Here are some front-page articles. " + all_titles)

--- a/client/modules/Joke.py
+++ b/client/modules/Joke.py
@@ -44,16 +44,10 @@ def handle(text, mic, profile):
     joke = getRandomJoke()
 
     mic.say("Knock knock")
-
-    def firstLine(text):
-        mic.say(joke[0])
-
-        def punchLine(text):
-            mic.say(joke[1])
-
-        punchLine(mic.activeListen())
-
-    firstLine(mic.activeListen())
+    mic.active_listen()
+    mic.say(joke[0])
+    mic.active_listen()
+    mic.say(joke[1])
 
 
 def isValid(text):

--- a/client/modules/MPDControl.py
+++ b/client/modules/MPDControl.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8-*-
 import re
+import copy
 import logging
 import difflib
 import mpd
-from client.mic import Mic
 
 # Standard module stuff
 WORDS = ["MUSIC", "SPOTIFY"]
@@ -77,9 +77,8 @@ class MusicMode(object):
 
         music_stt_engine = mic.active_stt_engine.get_instance('music', phrases)
 
-        self.mic = Mic(mic.speaker,
-                       mic.passive_stt_engine,
-                       music_stt_engine)
+        self.mic = copy.copy(mic)
+        self.mic.active_stt_engine = music_stt_engine
 
     def delegateInput(self, input):
 
@@ -161,15 +160,9 @@ class MusicMode(object):
 
         while True:
 
-            threshold, transcribed = self.mic.passiveListen(self.persona)
-
-            if not transcribed or not threshold:
-                self._logger.info("Nothing has been said or transcribed.")
-                continue
-
+            self.mic.wait_for_keyword(self.persona)
             self.music.pause()
-
-            input = self.mic.activeListen(MUSIC=True)
+            input = self.mic.active_listen()[0]
 
             if input:
                 if "close" in input.lower():

--- a/client/modules/News.py
+++ b/client/modules/News.py
@@ -114,7 +114,7 @@ def handle(text, mic, profile):
         mic.say("Here are the current top headlines. " + all_titles +
                 ". Would you like me to send you these articles? " +
                 "If so, which?")
-        handleResponse(mic.activeListen())
+        handleResponse(mic.active_listen()[0])
 
     else:
         mic.say(

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -2,6 +2,7 @@
 APScheduler==3.0.1
 argparse==1.2.2
 mock==1.0.1
+python-slugify==0.1.0
 pytz==2014.10
 PyYAML==3.11
 requests==2.5.0

--- a/client/test_mic.py
+++ b/client/test_mic.py
@@ -13,21 +13,13 @@ class Mic:
         self.idx = 0
         self.outputs = []
 
-    def passiveListen(self, PERSONA):
-        return True, "JASPER"
+    def wait_for_keyword(self, keyword="JASPER"):
+        return
 
-    def activeListenToAllOptions(self, THRESHOLD=None, LISTEN=True,
-                                 MUSIC=False):
-        return [self.activeListen(THRESHOLD=THRESHOLD, LISTEN=LISTEN,
-                                  MUSIC=MUSIC)]
-
-    def activeListen(self, THRESHOLD=None, LISTEN=True, MUSIC=False):
-        if not LISTEN:
-            return self.inputs[self.idx - 1]
-
+    def active_listen(self, timeout=3):
         input = self.inputs[self.idx]
         self.idx += 1
-        return input
+        return [input]
 
     def say(self, phrase, OPTIONS=None):
         self.outputs.append(phrase)

--- a/client/tts.py
+++ b/client/tts.py
@@ -281,8 +281,11 @@ class FliteTTS(AbstractTTSEngine):
             output = out_f.read().strip()
         if output:
             self._logger.debug("Output was: '%s'", output)
-        self.play(fname)
+
+        with open(fname, 'rb') as f:
+            data = f.read()
         os.remove(fname)
+        return data
 
 
 class MacOSXTTS(AbstractTTSEngine):

--- a/client/tts.py
+++ b/client/tts.py
@@ -60,19 +60,6 @@ class AbstractTTSEngine(object):
     def say(self, phrase, *args):
         pass
 
-    def play(self, filename):
-        # FIXME: Use platform-independent audio-output here
-        # See issue jasperproject/jasper-client#188
-        cmd = ['aplay', '-D', 'hw:1,0', str(filename)]
-        self._logger.debug('Executing %s', ' '.join([pipes.quote(arg)
-                                                     for arg in cmd]))
-        with tempfile.TemporaryFile() as f:
-            subprocess.call(cmd, stdout=f, stderr=f)
-            f.seek(0)
-            output = f.read()
-            if output:
-                self._logger.debug("Output was: '%s'", output)
-
 
 class AbstractMp3TTSEngine(AbstractTTSEngine):
     """
@@ -83,20 +70,23 @@ class AbstractMp3TTSEngine(AbstractTTSEngine):
         return (super(AbstractMp3TTSEngine, cls).is_available() and
                 diagnose.check_python_import('mad'))
 
-    def play_mp3(self, filename):
+    def mp3_to_wave(self, filename):
         mf = mad.MadFile(filename)
-        with tempfile.NamedTemporaryFile(suffix='.wav') as f:
+        with tempfile.SpooledTemporaryFile() as f:
             wav = wave.open(f, mode='wb')
             wav.setframerate(mf.samplerate())
             wav.setnchannels(1 if mf.mode() == mad.MODE_SINGLE_CHANNEL else 2)
             # 4L is the sample width of 32 bit audio
-            wav.setsampwidth(4L)
+            wav.setsampwidth(4)
             frame = mf.read()
             while frame is not None:
                 wav.writeframes(frame)
                 frame = mf.read()
             wav.close()
-            self.play(f.name)
+            wavread = wave.open(f, mode='rb')
+            data = wavread.readframes()
+            wavread.close()
+        return data
 
 
 class DummyTTS(AbstractTTSEngine):
@@ -172,14 +162,10 @@ class EspeakTTS(AbstractTTSEngine):
         cmd = [str(x) for x in cmd]
         self._logger.debug('Executing %s', ' '.join([pipes.quote(arg)
                                                      for arg in cmd]))
-        with tempfile.TemporaryFile() as f:
-            subprocess.call(cmd, stdout=f, stderr=f)
-            f.seek(0)
-            output = f.read()
-            if output:
-                self._logger.debug("Output was: '%s'", output)
-        self.play(fname)
+        with open(fname, 'rb') as f:
+            data = f.read()
         os.remove(fname)
+        return data
 
 
 class FestivalTTS(AbstractTTSEngine):
@@ -214,7 +200,7 @@ class FestivalTTS(AbstractTTSEngine):
     def say(self, phrase):
         self._logger.debug("Saying '%s' with '%s'", phrase, self.SLUG)
         cmd = ['text2wave']
-        with tempfile.NamedTemporaryFile(suffix='.wav') as out_f:
+        with tempfile.SpooledTemporaryFile() as out_f:
             with tempfile.SpooledTemporaryFile() as in_f:
                 in_f.write(phrase)
                 in_f.seek(0)
@@ -228,7 +214,8 @@ class FestivalTTS(AbstractTTSEngine):
                     output = err_f.read()
                     if output:
                         self._logger.debug("Output was: '%s'", output)
-            self.play(out_f.name)
+            out_f.seek(0)
+            return out_f.read()
 
 
 class FliteTTS(AbstractTTSEngine):
@@ -403,8 +390,10 @@ class PicoTTS(AbstractTTSEngine):
             output = f.read()
             if output:
                 self._logger.debug("Output was: '%s'", output)
-        self.play(fname)
+        with open(fname, 'rb') as f:
+            data = f.read()
         os.remove(fname)
+        return data
 
 
 class GoogleTTS(AbstractMp3TTSEngine):
@@ -459,8 +448,9 @@ class GoogleTTS(AbstractMp3TTSEngine):
         with tempfile.NamedTemporaryFile(suffix='.mp3', delete=False) as f:
             tmpfile = f.name
         tts.save(tmpfile)
-        self.play_mp3(tmpfile)
+        data = self.mp3_to_wave(tmpfile)
         os.remove(tmpfile)
+        return data
 
 
 class MaryTTS(AbstractTTSEngine):
@@ -551,11 +541,7 @@ class MaryTTS(AbstractTTSEngine):
                  'VOICE': self.voice}
 
         r = self.session.get(self._makeurl('/process', query=query))
-        with tempfile.NamedTemporaryFile(suffix='.wav', delete=False) as f:
-            f.write(r.content)
-            tmpfile = f.name
-        self.play(tmpfile)
-        os.remove(tmpfile)
+        return r.content
 
 
 def get_default_engine_slug():

--- a/client/tts.py
+++ b/client/tts.py
@@ -295,31 +295,28 @@ class MacOSXTTS(AbstractTTSEngine):
     @classmethod
     def is_available(cls):
         return (platform.system().lower() == 'darwin' and
-                diagnose.check_executable('say') and
-                diagnose.check_executable('afplay'))
+                diagnose.check_executable('say'))
 
     def say(self, phrase):
         self._logger.debug("Saying '%s' with '%s'", phrase, self.SLUG)
-        cmd = ['say', str(phrase)]
+        with tempfile.NamedTemporaryFile(suffix='.wav', delete=False) as f:
+            fname = f.name
+        cmd = ['say', '-o', fname,
+                      '--file-format=WAVE',
+                      str(phrase)]
         self._logger.debug('Executing %s', ' '.join([pipes.quote(arg)
                                                      for arg in cmd]))
-        with tempfile.TemporaryFile() as f:
+        with tempfile.SpooledTemporaryFile() as f:
             subprocess.call(cmd, stdout=f, stderr=f)
             f.seek(0)
             output = f.read()
             if output:
                 self._logger.debug("Output was: '%s'", output)
 
-    def play(self, filename):
-        cmd = ['afplay', str(filename)]
-        self._logger.debug('Executing %s', ' '.join([pipes.quote(arg)
-                                                     for arg in cmd]))
-        with tempfile.TemporaryFile() as f:
-            subprocess.call(cmd, stdout=f, stderr=f)
-            f.seek(0)
-            output = f.read()
-            if output:
-                self._logger.debug("Output was: '%s'", output)
+        with open(fname, 'rb') as f:
+            data = f.read()
+        os.remove(fname)
+        return data
 
 
 class PicoTTS(AbstractTTSEngine):

--- a/jasper.py
+++ b/jasper.py
@@ -99,21 +99,57 @@ class Jasper(object):
         # Initialize AudioEngine
         audio = audioengine.PyAudioEngine()
 
+        # Initialize audio input device
+        devices = [device.slug for device
+                   in audio.get_input_devices()]
         try:
-            input_device_slug = self.config['input_device']
+            if len(devices) == 0:
+                raise RuntimeError("Can't find any input devices")
+            device_slug = self.config['input_device']
+        except RuntimeError as e:
+            logger.critical(e.args[0])
+            raise
         except KeyError:
-            input_device_slug = 'default'
+            device_slug = 'default' if 'default' in devices else devices[0]
             logger.warning("input_device not specified in profile, " +
-                           "defaulting to '%s'", input_device_slug)
-        input_device = audio.get_device_by_slug(input_device_slug)
-
+                           "defaulting to '%s' (Possible values: %s)",
+                           device_slug, ', '.join(devices))
         try:
-            output_device_slug = self.config['output_device']
+            input_device = audio.get_device_by_slug(device_slug)
+            if not input_device.is_input_device:
+                raise audioengine.UnsupportedFormat(
+                    "Audio device with slug '%s' is not an input device"
+                    % input_device.slug)
+        except (audioengine.DeviceException) as e:
+            logger.critical(e.args[0])
+            logger.warning('Valid output devices: %s', ', '.join(devices))
+            raise
+
+        # Initialize audio output device
+        devices = [device.slug for device
+                   in audio.get_output_devices()]
+        try:
+            if len(devices) == 0:
+                raise RuntimeError("Can't find any output devices")
+            device_slug = self.config['output_device']
+        except RuntimeError as e:
+            logger.critical(e.args[0])
+            raise
         except KeyError:
-            output_device_slug = 'default'
+            device_slug = 'default' if 'default' in devices else devices[0]
             logger.warning("output_device not specified in profile, " +
-                           "defaulting to '%s'", input_device_slug)
-        output_device = audio.get_device_by_slug(output_device_slug)
+                           "defaulting to '%s' (Possible values: %s)",
+                           device_slug, ', '.join(devices))
+        try:
+            output_device = audio.get_device_by_slug(device_slug)
+            if not output_device.is_output_device:
+                raise audioengine.UnsupportedFormat(
+                    "Audio device with slug '%s' is not an output device"
+                    % output_device.slug)
+        except (audioengine.DeviceException) as e:
+            logger.critical(e.args[0])
+            logger.warning('Valid output devices: %s', ', '.join(devices))
+            raise
 
         # Initialize Mic
         self.mic = Mic(input_device, output_device,

--- a/jasper.py
+++ b/jasper.py
@@ -103,14 +103,9 @@ class Jasper(object):
         devices = [device.slug for device
                    in audio.get_input_devices()]
         try:
-            if len(devices) == 0:
-                raise RuntimeError("Can't find any input devices")
             device_slug = self.config['input_device']
-        except RuntimeError as e:
-            logger.critical(e.args[0])
-            raise
         except KeyError:
-            device_slug = 'default' if 'default' in devices else devices[0]
+            device_slug = audio.get_default_input_device().slug
             logger.warning("input_device not specified in profile, " +
                            "defaulting to '%s' (Possible values: %s)",
                            device_slug, ', '.join(devices))
@@ -129,14 +124,9 @@ class Jasper(object):
         devices = [device.slug for device
                    in audio.get_output_devices()]
         try:
-            if len(devices) == 0:
-                raise RuntimeError("Can't find any output devices")
             device_slug = self.config['output_device']
-        except RuntimeError as e:
-            logger.critical(e.args[0])
-            raise
         except KeyError:
-            device_slug = 'default' if 'default' in devices else devices[0]
+            device_slug = audio.get_default_output_device().slug
             logger.warning("output_device not specified in profile, " +
                            "defaulting to '%s' (Possible values: %s)",
                            device_slug, ', '.join(devices))


### PR DESCRIPTION
With this PR, I added `audioengine.py` which acts as a wrapper, so that it contains all PyAudio-related stuff. This way, we can change the backend (PyAudio) easily, if that ever becomes neccessary.

Also, this makes input/output audio devices configurable in `profile.yml` via a slugified device name (not the PyAudio device index). If you have not specified them, Jasper will either try to use the `default` device or - if that does not exist - the first `device` available.

`tts.py` does not contain playback logic anymore. Instead, the `say` method returns binary WAVE data, that can be played back with an `audioengine` device. We also get rid of `aplay` calls any rely solely on PyAudio for that matter.

Because it seemed easier to rewrite `mic.py` instead of integrating it into the current code, I did it while reusing some ideas from my [listen-forever branch](https://github.com/Holzhaus/jasper-client/commit/1c4c249c6b552e3b9d184cd331c80f1413f9806b) (i.e. recording all the time until keyword was said instead of opening/closing the stream all the time).

## TODO
- [X] MacOS X TTS integration
- [x] Changing Modules to match new API
- [x] Probably something else, too

*Note: This a first draft, there will be some commits before this can be merged.*

