### PR TITLE
Update tts.py

### DIFF
--- a/client/tts.py
+++ b/client/tts.py
@@ -63,7 +63,7 @@ class AbstractTTSEngine(object):
     def play(self, filename):
         # FIXME: Use platform-independent audio-output here
         # See issue jasperproject/jasper-client#188
-        cmd = ['aplay', '-D', 'hw:1,0', str(filename)]
+        cmd = ['aplay',str(filename)]
         self._logger.debug('Executing %s', ' '.join([pipes.quote(arg)
                                                      for arg in cmd]))
         with tempfile.TemporaryFile() as f:


### PR DESCRIPTION
full option cmd line creates an aplay exception on my raspbian and no sound is playing :

aplay: set_params:1081: Sample format non available
Available formats:
- U8
- S16_LE