### PR TITLE
Add config option to allow different stt engines for passive and active modes

### DIFF
--- a/jasper.py
+++ b/jasper.py
@@ -88,6 +88,12 @@ class Jasper(object):
         stt_engine_class = stt.get_engine_by_slug(stt_engine_slug)
 
         try:
+            slug = self.config['stt_passive_engine']
+            stt_passive_engine_class = stt.get_engine_by_slug(slug)
+        except KeyError:
+            stt_passive_engine_class = stt_engine_class
+
+        try:
             tts_engine_slug = self.config['tts_engine']
         except KeyError:
             tts_engine_slug = tts.get_default_engine_slug()
@@ -97,7 +103,7 @@ class Jasper(object):
 
         # Initialize Mic
         self.mic = Mic(tts_engine_class.get_instance(),
-                       stt_engine_class.get_passive_instance(),
+                       stt_passive_engine_class.get_passive_instance(),
                        stt_engine_class.get_active_instance())
 
     def run(self):


### PR DESCRIPTION
The objective of this change is to easily allow 2 different stt engines to be run for passive and active modes.

This enables to keep the passive detection local and fast, while the active detection can use remote, slower and more accurate speech to text.

I wanted to be able to use sphinx for the passive detection, and google for the active detection. This would mean faster passive responses, and not sending all data over the net. 

This change allows for a new config option 'stt_passive_engine', which will override the stt_engine for the passive detection.  If 'stt_passive_engine' isn't set, it will default to stt_engine.  

So this should be fully backwards compatible.