### PR TITLE
witai-stt: small fix to check if result is empty

### DIFF
--- a/client/stt.py
+++ b/client/stt.py
@@ -610,7 +610,9 @@ class WitAiSTT(AbstractSTTEngine):
                                   exc_info=True)
             return []
         else:
-            transcribed = [text.upper()]
+            transcribed = []
+            if text:
+                transcribed.append(text.upper())
             self._logger.info('Transcribed: %r', transcribed)
             return transcribed
 


### PR DESCRIPTION
Fixes a rare condition when Wit.ai returns a NoneType. Resolves jasperproject/jasper-client#327.