### PR TITLE
Named entity trees

### DIFF
--- a/client/taggedtext.py
+++ b/client/taggedtext.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8-*-
+import unittest
+
+
+class TaggedText(unicode):
+    def __new__(cls, u, tags):
+        return unicode.__new__(cls, u)
+
+    def __init__(self, u, tags):
+        super(self.__class__, self).__init__(u)
+        self._tags = tags
+
+    @property
+    def tags(self):
+        return self._tags
+
+
+class TestTaggedText(unittest.TestCase):
+
+    def test_unicode(self):
+        """Does TaggedText behave like a normal unicode string"""
+        t = TaggedText("hello world", {})
+        self.assertEqual(t, "hello world")
+        self.assertIn("world", t)
+
+    def test_tags(self):
+        """Does TaggedText allow access to tags"""
+        t = TaggedText("hello world", {})
+        self.assertEqual(t.tags, {})
+
+    def test_immutability(self):
+        """Does TaggedText disallow assignment"""
+        t = TaggedText("hello world", {})
+        with self.assertRaises(AttributeError):
+            t.tags = {}


### PR DESCRIPTION
# Rationale

STTs like [wit.ai](https://wit.ai) (site requires webkit-based browser), along with the raw text they transcribe, also return a tree (or trees) of named entities identified from the text.
Named-entity trees provide considerably more reliable identification of the speaker's intent than simple word extraction and making use of them can shift a significant amount of error-prone work outside of the modules.
# Changes

This change updates `WitAiSTT.transcribe()` to attach the named entity trees to transcribed text. To make this change transparent and backwards-compatible with existing modules, `class TaggedText` (a subclass of `unicode`) is introduced.
# Example wit.ai response including named-entity data

``` json
{
  "msg_id": "5d7647b5-3970-44d5-94a0-d286773c0c98",
  "_text": "Lounge lights on",
  "outcomes": [
    {
      "_text": "Lounge lights on",
      "intent": "lights",
      "entities": {
        "on_off": [
          {
            "value": "on"
          }
        ],
        "room": [
          {
            "value": "lounge",
            "metadata": ""
          }
        ],
        "light_group": [
          {
            "suggested": true,
            "value": "lights",
            "type": "value"
          }
        ]
      },
      "confidence": 0.985
    }
  ]
}
```

The example is trained based on my [wit.ai Home Automation app](https://wit.ai/markferry/home%20automation).
# Usage

``` python
def handle(text, mic, profile):
    if hasattr(text, 'tags') and len(text.tags) > 0:
        _handle_entity_tree(text, mic, profile)
    else:
        # the usual handle function
        _handle_text(text, mic, profile)
...
def _handle_entity_tree(tagged_text, mic, profile):
    tree = tagged_text.tags
    # parse named-entity-tree
```
