### PR TITLE
Changed audio device to sysdefault

### DIFF
--- a/client/tts.py
+++ b/client/tts.py
@@ -73,7 +73,7 @@ class AbstractTTSEngine(object):
     def play(self, filename):
         # FIXME: Use platform-independent audio-output here
         # See issue jasperproject/jasper-client#188
-        cmd = ['aplay', '-D', 'plughw:1,0', str(filename)]
+        cmd = ['aplay', '-D', 'sysdefault', str(filename)]
         self._logger.debug('Executing %s', ' '.join([pipes.quote(arg)
                                                      for arg in cmd]))
         with tempfile.TemporaryFile() as f:


### PR DESCRIPTION
In audio device 'plughw:1,0', I was not getting any audio output. I used command "aplay -L" to find out default audio device which was in my case 'sysdefault'.

For other users it might not be 'sysdefault', but they can check for audio device with caption "Default Audio Device"  though command "aplay -L" and choose the correct audio device for audio output.