### PR TITLE
Added passive STT configuration in populate.py

### DIFF
--- a/client/populate.py
+++ b/client/populate.py
@@ -123,6 +123,17 @@ def run():
               % stt_engines.keys())
         profile["stt_engine"] = "sphinx"
 
+    if response == "google":
+        response = raw_input("\nChoosing Google means every sound " +
+                             "makes a request online. " +
+                             "\nWould you like to process the wake up word " +
+                             "locally with PocketSphinx? (Y) or (N)?")
+        while not response or (response != 'Y' and response != 'N'):
+            response = raw_input("Please choose PocketSphinx (Y) " +
+                                 "or keep just Google (N): ")
+        if response == 'Y':
+            profile['stt_passive_engine'] = "sphinx"
+
     # write to profile
     print("Writing to profile...")
     if not os.path.exists(jasperpath.CONFIG_PATH):


### PR DESCRIPTION
The passive STT is already avaiable in master branch but didn't know until I read in the forum about it.
I choose an online STT but can't send online every sound in my home while waiting for "Jasper" hotword.

So I modified populate and added the configuration to my profile.

Despite Populate may be deleted in version 2 I'm willing to share it with you, and if accepted I will add a note to the documentation for every future user.