### PR TITLE
Fixed WIT API response text parsing

### DIFF
--- a/client/stt.py
+++ b/client/stt.py
@@ -592,7 +592,7 @@ class WitAiSTT(AbstractSTTEngine):
                           headers=self.headers)
         try:
             r.raise_for_status()
-            text = r.json()['_text']
+            text = json.loads(r.content)['_text'].decode('unicode_escape').encode('ascii', 'ignore')
         except requests.exceptions.HTTPError:
             self._logger.critical('Request failed with response: %r',
                                   r.text,


### PR DESCRIPTION
While testing out Jasper Client, I ran into the following parsing error when using the WIT API:

    Traceback (most recent call last):
      File "client/../jasper.py", line 148, in <module>
        app.run()
      File "client/../jasper.py", line 118, in run
        conversation.handleForever()
      File "/home/pi/jasper/jasper-client/client/conversation.py", line 31, in handleForever
        threshold, transcribed = self.mic.passiveListen(self.persona)
      File "/home/pi/jasper/jasper-client/client/mic.py", line 179, in passiveListen
        transcribed = self.passive_stt_engine.transcribe(f)
      File "/home/pi/jasper/jasper-client/client/stt.py", line 595, in transcribe
        text = r.json()['_text']
    TypeError: 'dict' object is not callable

It appeared there was a bug with how Jasper was handling the response object from the WIT API server. For an undetermined reason, the response object was not correctly being parsed. Instead, this problem was resolved by first converting the response content received to JSON, pulling out the `_text` key, and then stripping out the Unicode characters.

After this fix, everything seemed to function normally:

    INFO:client.stt:Transcribed: []
    INFO:client.stt:Transcribed: ['HELLO']
    INFO:client.stt:Transcribed: []
    INFO:client.stt:Transcribed: ['DOES THIS WORK']
    INFO:client.stt:Transcribed: ['IT LOOKS LIKE IT DOES']
    INFO:client.stt:Transcribed: []
    INFO:client.stt:Transcribed: []

I'm not sure why this calling [`r.json()`](http://docs.python-requests.org/en/latest/user/quickstart/#json-response-content) was generating this error and how this differs from [`json.loads(r.content)`](http://docs.python-requests.org/en/latest/user/quickstart/#binary-response-content). While this could be something to look into further, this pull request fixes the immediate problem, nonetheless.