### PR TITLE
RESTful API

### DIFF
--- a/jasper/application.py
+++ b/jasper/application.py
@@ -12,6 +12,7 @@ from . import pluginstore
 from . import conversation
 from . import mic
 from . import local_mic
+from . import restapi
 
 
 class Jasper(object):
@@ -220,6 +221,9 @@ class Jasper(object):
 
         self.conversation = conversation.Conversation(
             self.mic, self.brain, self.config)
+
+        # Initialize RESTful API
+        self.restapi = restapi.RestAPI(self.config, self.mic, self.conversation)
 
     def list_plugins(self):
         plugins = self.plugins.get_plugins()

--- a/jasper/application.py
+++ b/jasper/application.py
@@ -223,7 +223,8 @@ class Jasper(object):
             self.mic, self.brain, self.config)
 
         # Initialize RESTful API
-        self.restapi = restapi.RestAPI(self.config, self.mic, self.conversation)
+        self.restapi = restapi.RestAPI(self.config, self.mic,
+                                       self.conversation)
 
     def list_plugins(self):
         plugins = self.plugins.get_plugins()

--- a/jasper/conversation.py
+++ b/jasper/conversation.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from time import sleep
 from . import paths
 from . import i18n
 #  from notifier import Notifier
@@ -16,6 +17,7 @@ class Conversation(i18n.GettextMixin):
         self.translations = {
 
         }
+        self.suspended = False
         #  self.notifier = Notifier(profile)
 
     def greet(self):
@@ -26,33 +28,54 @@ class Conversation(i18n.GettextMixin):
             salutation = self.gettext("How can I be of service?")
         self.mic.say(salutation)
 
+    def handleInput(self, input):
+        if input:
+            plugin, text = self.brain.query(input)
+            if plugin and text:
+                try:
+                    plugin.handle(text, self.mic)
+                except Exception:
+                    self._logger.error('Failed to execute module',
+                                       exc_info=True)
+                    self.mic.say(self.gettext(
+                        "I'm sorry. I had some trouble with that " +
+                        "operation. Please try again later."))
+                else:
+                    self._logger.debug("Handling of phrase '%s' by " +
+                                       "module '%s' completed", text,
+                                       plugin.info.name)
+                    return True
+        else:
+            self.mic.say(self.gettext("Pardon?"))
+
+        return False
+
     def handleForever(self):
         """
         Delegates user input to the handling function when activated.
         """
         self._logger.debug('Starting to handle conversation.')
         while True:
-            # Print notifications until empty
-            """notifications = self.notifier.get_all_notifications()
-            for notif in notifications:
-                self._logger.info("Received notification: '%s'", str(notif))"""
+            if not self.suspended:
+                input = self.mic.listen()
 
-            input = self.mic.listen()
+            if not self.suspended:
+                self.handleInput(input)
 
-            if input:
-                plugin, text = self.brain.query(input)
-                if plugin and text:
-                    try:
-                        plugin.handle(text, self.mic)
-                    except Exception:
-                        self._logger.error('Failed to execute module',
-                                           exc_info=True)
-                        self.mic.say(self.gettext(
-                            "I'm sorry. I had some trouble with that " +
-                            "operation. Please try again later."))
-                    else:
-                        self._logger.debug("Handling of phrase '%s' by " +
-                                           "module '%s' completed", text,
-                                           plugin.info.name)
-            else:
-                self.mic.say(self.gettext("Pardon?"))
+            if self.suspended:
+                sleep(0.25)
+
+    def suspend(self):
+        """
+        Suspends converstation handling
+        """
+        self._logger.debug('Suspending handling conversation.')
+        self.suspended = True
+        self.mic.cancel_listen()
+    
+    def resume(self):
+        """
+        Resumes converstation handling
+        """
+        self._logger.debug('Resuming handling conversation.')
+        self.suspended = False

--- a/jasper/conversation.py
+++ b/jasper/conversation.py
@@ -56,6 +56,11 @@ class Conversation(i18n.GettextMixin):
         """
         self._logger.debug('Starting to handle conversation.')
         while True:
+            # Print notifications until empty
+            """notifications = self.notifier.get_all_notifications()
+            for notif in notifications:
+                self._logger.info("Received notification: '%s'", str(notif))"""
+
             if not self.suspended:
                 input = self.mic.listen()
 
@@ -72,7 +77,7 @@ class Conversation(i18n.GettextMixin):
         self._logger.debug('Suspending handling conversation.')
         self.suspended = True
         self.mic.cancel_listen()
-    
+
     def resume(self):
         """
         Resumes converstation handling

--- a/jasper/mic.py
+++ b/jasper/mic.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from . import alteration
+from . import paths
 import logging
 import tempfile
 import wave
@@ -12,9 +14,6 @@ if sys.version_info < (3, 0):
     import Queue as queue
 else:
     import queue
-
-from . import alteration
-from . import paths
 
 
 def get_config_value(config, name, default):
@@ -188,7 +187,7 @@ class Mic(object):
                             audioop.rms(b"".join(frames), 2))
             if self.cancelListen:
                 return False
-                            
+
     def listen(self):
         self.cancelListen = False
         if self.wait_for_keyword(self._keyword):
@@ -198,8 +197,8 @@ class Mic(object):
 
     def cancel_listen(self):
         self.cancelListen = True
-        
-    def active_listen(self, timeout=1.5):
+
+    def active_listen(self, timeout=3):
         # record until <timeout> second of silence or double <timeout>.
         n = int(round((self._input_rate/self._input_chunksize)*timeout))
         self.play_file(paths.data('audio', 'beep_hi.wav'))

--- a/jasper/pluginstore.py
+++ b/jasper/pluginstore.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from . import i18n
+from . import plugin
 import os
 import logging
 import imp
@@ -8,9 +10,6 @@ if sys.version_info < (3, 0):
     import ConfigParser as configparser
 else:
     import configparser
-
-from . import i18n
-from . import plugin
 
 
 MANDATORY_OPTIONS = (

--- a/jasper/restapi.py
+++ b/jasper/restapi.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+from jasper import plugin
+from flask import  Flask, jsonify, request, Response, abort
+#import json
+import threading
+import logging
+from functools import wraps
+
+
+class RestAPI(object):
+
+    def __init__(self, profile, mic, conversation):
+        self.profile = profile
+        self.mic = mic
+        self.conversation = conversation
+
+        try:
+            host = self.profile['restapi']['Host']
+        except KeyError:
+            host = '127.0.0.1'
+
+        try:
+            port = self.profile['restapi']['Port']
+        except KeyError:
+            port = 5000
+
+        try:
+            password = self.profile['restapi']['Password']
+        except KeyError:
+            password = None
+
+        # create thread for http listener
+        t = threading.Thread(target=self.startRestAPI, args=(host, port, password))
+        t.daemon = True
+        t.start()
+
+    def startRestAPI(self, host, port, password):
+        app = Flask(__name__)
+
+        def requires_auth(f):
+            @wraps(f)
+            def decorated(*args, **kwargs):
+                auth = request.authorization
+                if password and (not auth or auth.password != password):
+                    return Response(
+                    'Authorization required.', 401,
+                    {'WWW-Authenticate': 'Basic realm="Login Required"'})
+                return f(*args, **kwargs)
+            return decorated
+            
+        
+        @app.route('/')
+        def index():
+            return "Jasper restAPI: running"
+
+        @app.route('/jasper/say', methods=['POST'])
+        @requires_auth
+        def say_task():
+            if not request.json or not 'text' in request.json:
+                abort(400)
+            text = request.json['text']
+
+            self.conversation.suspend()
+            self.mic.say(text)
+            self.conversation.resume()
+
+            return jsonify({'say': text}), 201
+
+        @app.route('/jasper/transcribe', methods=['GET'])
+        @requires_auth
+        def transcribe_task():
+            self.conversation.suspend()
+            transcribed = self.mic.active_listen()
+            self.conversation.resume()
+
+            return jsonify({'transcribed':transcribed}), 201
+
+        @app.route('/jasper/activate', methods=['GET'])
+        @requires_auth
+        def activate_task():
+            self.conversation.suspend()
+            transcribed = self.mic.active_listen()
+            result = self.conversation.handleInput(transcribed)
+            self.conversation.resume()
+
+            return jsonify({'transcribed':transcribed, 'result':result}), 201
+
+        @app.route('/jasper/handleinput', methods=['POST'])
+        @requires_auth
+        def handleinput_task():
+            if not request.json or not 'text' in request.json:
+                abort(400)
+            text = request.json['text']
+
+            self.conversation.suspend()
+            result = self.conversation.handleInput([text])
+            self.conversation.resume()
+
+            return jsonify({'text':text, 'result':result}), 201
+
+        @app.route('/jasper/waitforkeyword', methods=['POST'])
+        @requires_auth
+        def waitforkeyword_task():
+            if not request.json or not 'keyword' in request.json:
+                abort(400)
+            keyword = request.json['keyword']
+
+            self.conversation.suspend()
+            self.mic.wait_for_keyword(keyword)
+            self.conversation.resume()
+
+            return jsonify({'keyword': keyword}), 201
+
+        @app.route('/jasper/playfile', methods=['POST'])
+        @requires_auth
+        def playfile_task():
+            if not request.json or not 'filename' in request.json:
+                abort(400)
+            filename = request.json['filename']
+
+            self.conversation.suspend()
+            self.mic.play_file(filename)
+            self.conversation.resume()
+
+            return jsonify({'filename': filename}), 201
+
+
+        # start http listener
+        app.run(host=host, port=port, debug=False)

--- a/jasper/restapi.py
+++ b/jasper/restapi.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
-from jasper import plugin
-from flask import  Flask, jsonify, request, Response, abort
-#import json
+from flask import Flask, jsonify, request, Response, abort
 import threading
-import logging
 from functools import wraps
 
 
@@ -30,7 +27,8 @@ class RestAPI(object):
             password = None
 
         # create thread for http listener
-        t = threading.Thread(target=self.startRestAPI, args=(host, port, password))
+        t = threading.Thread(target=self.startRestAPI,
+                             args=(host, port, password))
         t.daemon = True
         t.start()
 
@@ -43,12 +41,11 @@ class RestAPI(object):
                 auth = request.authorization
                 if password and (not auth or auth.password != password):
                     return Response(
-                    'Authorization required.', 401,
-                    {'WWW-Authenticate': 'Basic realm="Login Required"'})
+                        'Authorization required.', 401,
+                        {'WWW-Authenticate': 'Basic realm="Login Required"'})
                 return f(*args, **kwargs)
             return decorated
-            
-        
+
         @app.route('/')
         def index():
             return "Jasper restAPI: running"
@@ -56,7 +53,7 @@ class RestAPI(object):
         @app.route('/jasper/say', methods=['POST'])
         @requires_auth
         def say_task():
-            if not request.json or not 'text' in request.json:
+            if not request.json or 'text' not in request.json:
                 abort(400)
             text = request.json['text']
 
@@ -73,7 +70,7 @@ class RestAPI(object):
             transcribed = self.mic.active_listen()
             self.conversation.resume()
 
-            return jsonify({'transcribed':transcribed}), 201
+            return jsonify({'transcribed': transcribed}), 201
 
         @app.route('/jasper/activate', methods=['GET'])
         @requires_auth
@@ -83,12 +80,12 @@ class RestAPI(object):
             result = self.conversation.handleInput(transcribed)
             self.conversation.resume()
 
-            return jsonify({'transcribed':transcribed, 'result':result}), 201
+            return jsonify({'transcribed': transcribed, 'result': result}), 201
 
         @app.route('/jasper/handleinput', methods=['POST'])
         @requires_auth
         def handleinput_task():
-            if not request.json or not 'text' in request.json:
+            if not request.json or 'text' not in request.json:
                 abort(400)
             text = request.json['text']
 
@@ -96,12 +93,12 @@ class RestAPI(object):
             result = self.conversation.handleInput([text])
             self.conversation.resume()
 
-            return jsonify({'text':text, 'result':result}), 201
+            return jsonify({'text': text, 'result': result}), 201
 
         @app.route('/jasper/waitforkeyword', methods=['POST'])
         @requires_auth
         def waitforkeyword_task():
-            if not request.json or not 'keyword' in request.json:
+            if not request.json or 'keyword' not in request.json:
                 abort(400)
             keyword = request.json['keyword']
 
@@ -114,7 +111,7 @@ class RestAPI(object):
         @app.route('/jasper/playfile', methods=['POST'])
         @requires_auth
         def playfile_task():
-            if not request.json or not 'filename' in request.json:
+            if not request.json or 'filename' not in request.json:
                 abort(400)
             filename = request.json['filename']
 
@@ -123,7 +120,6 @@ class RestAPI(object):
             self.conversation.resume()
 
             return jsonify({'filename': filename}), 201
-
 
         # start http listener
         app.run(host=host, port=port, debug=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ python-slugify==0.1.0
 pytz==2014.10
 PyYAML==3.11
 requests==2.5.0
+Flask==0.10.1
 
 # Pocketsphinx STT engine
 cmuclmtk==0.1.5


### PR DESCRIPTION
Adds a basic RESTful http api to Jasper using the Flask library (you may need to install using 'sudo pip2 install Flask').

Config options:

```
restapi:
   Host: 0.0.0.0
   Port: 5000
   Password: 'password'
```
- Host defaults to 127.0.0.1, which allows local connections only. Set to 0.0.0.0 to allow outside connections

Access through:

```
http://japser-ip:5000/jasper/[command]

ex: curl http://jasper-ip:5000/jasper/say -u :password -H 'Content-Type: application/json' -d '{"text":"Hello, this is Jasper"}'
```

Commands:

```
   say(text)
   transcribe()
   activate()
   handleinput(text)
   waitforkeyword(keyword) 
   playfile(filename)
```
