### PR TITLE
Update alsaaudioengine.py - wrong type

### DIFF
--- a/plugins/audioengine/alsa-ae/alsaaudioengine.py
+++ b/plugins/audioengine/alsa-ae/alsaaudioengine.py
@@ -50,7 +50,7 @@ class AlsaAudioEnginePlugin(plugin.AudioEnginePlugin):
             msg = 'No %s devices available!' % direction
             self._logger.warning(msg)
             raise plugin.audioengine.DeviceNotFound(msg)
-        return AlsaAudioDevice(devices[0])
+        return devices[0]
 
     def get_device_by_slug(self, slug):
         for device in self.get_devices():


### PR DESCRIPTION
`devices` is already an array of `AlsaAudioDevice`, you can't create a new instance by passing an existing instance in the constructor (it crashes, as it is expecting a string, the name of the device)

On a side note, I was testing the alsa audioengine, and I had the following crash from the alsaaudio library. I decreased the `input_chunksize`, but it didn't work even with very small values
```
alsaaudio.ALSAAudioError: Capture data too large. Try decreasing period size
```