### PR TITLE
Batch mode for jasper-dev

### DIFF
--- a/jasper/__main__.py
+++ b/jasper/__main__.py
@@ -43,6 +43,7 @@ def main(args=None):
     logging.basicConfig(level=logging.DEBUG if p_args.debug else logging.INFO)
 
     # Select Mic
+    batchfilecommands = []
     if p_args.local:
         # Use Local text mic
         used_mic = USE_TEXT_MIC
@@ -50,17 +51,16 @@ def main(args=None):
         # Use batched mode mic, pass a file too
         used_mic = USE_BATCH_MIC
 
-    # parse given batch file and get the filenames or commands
-    batchfilecommands = []
-    for line in p_args.batch_filename:
-        line = line.partition('#')[0]
-        if len(line.rstrip()) > 0:
-            batchfilecommands.append(line.rstrip())
-
-    # there should be something in the file
-    if len(batchfilecommands) == 0:
-        parser.error("The file %s has no content" % p_args.batch_filename.name)
-        p_args.batch_filename.close()
+        # parse given batch file and get the filenames or commands        
+        for line in p_args.batch_filename:
+            line = line.partition('#')[0]
+            if len(line.rstrip()) > 0:
+                batchfilecommands.append(line.rstrip())
+    
+        # there should be something in the file
+        if len(batchfilecommands) == 0:
+            parser.error("The file %s has no content" % p_args.batch_filename.name)
+            p_args.batch_filename.close()
     else:
         used_mic = USE_STANDARD_MIC
 

--- a/jasper/__main__.py
+++ b/jasper/__main__.py
@@ -46,18 +46,18 @@ def main(args=None):
     if p_args.local:
         # Use Local text mic
         used_mic = USE_TEXT_MIC
-    elif not p_args.batch_filename is None:
+    elif p_args.batch_filename is not None:
         # Use batched mode mic, pass a file too
         used_mic = USE_BATCH_MIC
 
-    #parse given batch file and get the filenames or commands
+    # parse given batch file and get the filenames or commands
     batchfilecommands = []
     for line in p_args.batch_filename:
         line = line.partition('#')[0]
         if len(line.rstrip()) > 0:
             batchfilecommands.append(line.rstrip())
 
-    #there should be something in the file
+    # there should be something in the file
     if len(batchfilecommands) == 0:
         parser.error("The file %s has no content" % p_args.batch_filename.name)
         p_args.batch_filename.close()

--- a/jasper/__main__.py
+++ b/jasper/__main__.py
@@ -3,13 +3,14 @@ import sys
 import logging
 import argparse
 import os.path
+import io
 
 from . import application
 from application import USE_STANDARD_MIC, USE_TEXT_MIC, USE_BATCH_MIC
 
 def is_valid_file(parser, arg):
     try:
-        fileid = open(arg, "r")
+        fileid = io.open(arg, "r",encoding="utf-8")
     except IOError:
         parser.error("The file %s does not exist!" % arg)   
     return fileid

--- a/jasper/__main__.py
+++ b/jasper/__main__.py
@@ -2,21 +2,22 @@
 import sys
 import logging
 import argparse
-import os.path
 import io
-
 from . import application
 from application import USE_STANDARD_MIC, USE_TEXT_MIC, USE_BATCH_MIC
 
+
 def is_valid_file(parser, arg):
+
     try:
-        fileid = io.open(arg, "r",encoding="utf-8")
+        fileid = io.open(arg, "r", encoding="utf-8")
     except IOError:
-        parser.error("The file %s does not exist!" % arg)   
+        parser.error("The file %s does not exist!" % arg)
     return fileid
 
 
 def main(args=None):
+
     parser = argparse.ArgumentParser(description='Jasper Voice Control Center')
     parser.add_argument('--local', action='store_true',
                         help='Use text input instead of a real microphone')
@@ -28,7 +29,9 @@ def main(args=None):
     list_info.add_argument('--list-audio-devices', action='store_true',
                            help='List audio devices and exit')
     parser.add_argument('--batch', dest='batch_filename', metavar="FILE",
-                    type=lambda x: is_valid_file(parser, x), help='Batch mode using a text file with text commands or audio filenames at each line. Use # for comments.')
+                        type=lambda x: is_valid_file(parser, x),
+                        help='Batch mode using a text file with text commands \
+                        or audio filenames at each line. Use # for comments.')
     p_args = parser.parse_args(args)
 
     print("*******************************************************")
@@ -41,27 +44,29 @@ def main(args=None):
 
     # Select Mic
     if p_args.local:
-	# Use Local text mic
-	used_mic=USE_TEXT_MIC	
-    elif not p_args.batch_filename == None:
-	# Use batched mode mic, pass a file too
-	used_mic=USE_BATCH_MIC
+        # Use Local text mic
+        used_mic = USE_TEXT_MIC
+    elif not p_args.batch_filename is None:
+        # Use batched mode mic, pass a file too
+        used_mic = USE_BATCH_MIC
 
-	#parse given batch file and get the filenames or commands
-	batchfilecommands = []
-	for line in p_args.batch_filename:
-        	line = line.partition('#')[0]
-		if len(line.rstrip())>0: batchfilecommands.append(line.rstrip())	
+    #parse given batch file and get the filenames or commands
+    batchfilecommands = []
+    for line in p_args.batch_filename:
+        line = line.partition('#')[0]
+        if len(line.rstrip()) > 0:
+            batchfilecommands.append(line.rstrip())
 
-	#there should be something in the file		
-	if len(batchfilecommands)==0:
-	 	parser.error("The file %s has no content" % p_args.batch_filename.name)	
-	p_args.batch_filename.close()		
+    #there should be something in the file
+    if len(batchfilecommands) == 0:
+        parser.error("The file %s has no content" % p_args.batch_filename.name)
+        p_args.batch_filename.close()
     else:
-	used_mic=USE_STANDARD_MIC	
+        used_mic = USE_STANDARD_MIC
 
     # Run Jasper
-    app = application.Jasper(use_mic=used_mic, batchfilecontent=batchfilecommands)
+    app = application.Jasper(use_mic=used_mic,
+                             batchfilecontent=batchfilecommands)
     if p_args.list_plugins:
         app.list_plugins()
         sys.exit(1)

--- a/jasper/__main__.py
+++ b/jasper/__main__.py
@@ -2,8 +2,17 @@
 import sys
 import logging
 import argparse
+import os.path
 
 from . import application
+from application import USE_STANDARD_MIC, USE_TEXT_MIC, USE_BATCH_MIC
+
+def is_valid_file(parser, arg):
+    try:
+        fileid = open(arg, "r")
+    except IOError:
+        parser.error("The file %s does not exist!" % arg)   
+    return fileid
 
 
 def main(args=None):
@@ -17,6 +26,8 @@ def main(args=None):
                            help='List plugins and exit')
     list_info.add_argument('--list-audio-devices', action='store_true',
                            help='List audio devices and exit')
+    parser.add_argument('--batch', dest='batch_filename', metavar="FILE",
+                    type=lambda x: is_valid_file(parser, x), help='Batch mode using a text file with text commands or audio filenames at each line. Use # for comments.')
     p_args = parser.parse_args(args)
 
     print("*******************************************************")
@@ -27,8 +38,29 @@ def main(args=None):
     # Set up logging
     logging.basicConfig(level=logging.DEBUG if p_args.debug else logging.INFO)
 
+    # Select Mic
+    if p_args.local:
+	# Use Local text mic
+	used_mic=USE_TEXT_MIC	
+    elif not p_args.batch_filename == None:
+	# Use batched mode mic, pass a file too
+	used_mic=USE_BATCH_MIC
+
+	#parse given batch file and get the filenames or commands
+	batchfilecommands = []
+	for line in p_args.batch_filename:
+        	line = line.partition('#')[0]
+		if len(line.rstrip())>0: batchfilecommands.append(line.rstrip())	
+
+	#there should be something in the file		
+	if len(batchfilecommands)==0:
+	 	parser.error("The file %s has no content" % p_args.batch_filename.name)	
+	p_args.batch_filename.close()		
+    else:
+	used_mic=USE_STANDARD_MIC	
+
     # Run Jasper
-    app = application.Jasper(use_local_mic=p_args.local)
+    app = application.Jasper(use_mic=used_mic, batchfilecontent=batchfilecommands)
     if p_args.list_plugins:
         app.list_plugins()
         sys.exit(1)

--- a/jasper/application.py
+++ b/jasper/application.py
@@ -15,10 +15,12 @@ from . import local_mic
 from . import batch_mic
 
 USE_STANDARD_MIC = 0
-USE_TEXT_MIC =  1
-USE_BATCH_MIC =  2
+USE_TEXT_MIC = 1
+USE_BATCH_MIC = 2
+
 
 class Jasper(object):
+
     def __init__(self, use_mic=USE_STANDARD_MIC, batchfilecontent=None):
         self._logger = logging.getLogger(__name__)
 
@@ -214,10 +216,12 @@ class Jasper(object):
         tts_plugin = tts_plugin_info.plugin_class(tts_plugin_info, self.config)
 
         # Initialize Mic
-        if use_mic==USE_TEXT_MIC:
+        if use_mic == USE_TEXT_MIC:
             self.mic = local_mic.Mic()
-	elif use_mic==USE_BATCH_MIC:
-	    self.mic = batch_mic.Mic(passive_stt_plugin, active_stt_plugin, batchfilecontent, keyword=keyword)
+        elif use_mic == USE_BATCH_MIC:
+            self.mic = batch_mic.Mic(passive_stt_plugin,
+                                     active_stt_plugin, batchfilecontent,
+                                     keyword=keyword)
         else:
             self.mic = mic.Mic(
                 input_device, output_device,

--- a/jasper/application.py
+++ b/jasper/application.py
@@ -218,15 +218,17 @@ class Jasper(object):
         # Initialize Mic
         if use_mic == USE_TEXT_MIC:
             self.mic = local_mic.Mic()
+	    self._logger.info("Using local text input and output")
         elif use_mic == USE_BATCH_MIC:
             self.mic = batch_mic.Mic(passive_stt_plugin,
                                      active_stt_plugin, batchfilecontent,
                                      keyword=keyword)
+	    self._logger.info("Using batched mode with %i commands", len(batchfilecontent))
         else:
             self.mic = mic.Mic(
                 input_device, output_device,
                 passive_stt_plugin, active_stt_plugin,
-                tts_plugin, self.config, keyword=keyword)
+                tts_plugin, self.config, keyword=keyword)	
 
         self.conversation = conversation.Conversation(
             self.mic, self.brain, self.config)

--- a/jasper/application.py
+++ b/jasper/application.py
@@ -12,10 +12,14 @@ from . import pluginstore
 from . import conversation
 from . import mic
 from . import local_mic
+from . import batch_mic
 
+USE_STANDARD_MIC = 0
+USE_TEXT_MIC =  1
+USE_BATCH_MIC =  2
 
 class Jasper(object):
-    def __init__(self, use_local_mic=False):
+    def __init__(self, use_mic=USE_STANDARD_MIC, batchfilecontent=None):
         self._logger = logging.getLogger(__name__)
 
         # Create config dir if it does not exist yet
@@ -210,8 +214,10 @@ class Jasper(object):
         tts_plugin = tts_plugin_info.plugin_class(tts_plugin_info, self.config)
 
         # Initialize Mic
-        if use_local_mic:
+        if use_mic==USE_TEXT_MIC:
             self.mic = local_mic.Mic()
+	elif use_mic==USE_BATCH_MIC:
+	    self.mic = batch_mic.Mic(passive_stt_plugin, active_stt_plugin, batchfilecontent, keyword=keyword)
         else:
             self.mic = mic.Mic(
                 input_device, output_device,

--- a/jasper/batch_mic.py
+++ b/jasper/batch_mic.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""
+Mic class impementation that allows for batch mode operation. Useful for debugging. Unlike with the typical Mic
+implementation, Jasper processes the given commands in the batchfile.
+"""
+import os.path
+import logging
+import sys
+#from . import mic
+
+class Mic(object):  
+    
+
+    def __init__(self, passive_stt_engine, active_stt_engine,
+                 batchfilecontent, keyword='JASPER'):
+	#mic.Mic.__init__(self, input_device, output_device,
+        #         passive_stt_engine, active_stt_engine,
+        #         tts_engine, config, keyword='JASPER')
+        self._logger = logging.getLogger(__name__)
+        self._keyword = keyword        
+        self.passive_stt_engine = passive_stt_engine
+        self.active_stt_engine = active_stt_engine        
+	self._batchcommands=batchfilecontent
+	self._nbrcommands=len(batchfilecontent)
+	self._batched_cmds=0
+        return
+
+    def transcribe_batchcommand(self, stt_engine):
+
+	#still unprocessed commands?
+	if self._nbrcommands<=self._batched_cmds: return False
+
+	command = self._batchcommands[self._batched_cmds]
+	self._batched_cmds += 1
+	#check if command is a filename	
+	if os.path.isfile(command):
+		#let's try open it  
+		fileid = None 		
+		try:
+        		fileid = open(command, "r")
+    		except IOError:
+        		self._logger.error("The file %s does not exist!" % command)   
+		else:
+			#handle it as mic input
+			try:
+                    		transcribed = stt_engine.transcribe(fileid)				
+                	except:
+                    		dbg = (self._logger.getEffectiveLevel() == logging.DEBUG)
+                    		self._logger.error("Transcription failed!", exc_info=dbg)
+				transcribed = False
+	else:
+		#handle it as text input
+		transcribed = [command]
+
+	return transcribed
+
+    def wait_for_keyword(self, keyword="JASPER"):
+        return
+
+    def active_listen(self, timeout=3):
+	#get transcribtion - either using audio or text
+	transcribed = self.transcribe_batchcommand(self.active_stt_engine)
+	if transcribed:			
+		print "YOU: " + " ".join(transcribed)
+        return transcribed
+
+    def listen(self):
+	#still unprocessed commands?
+	if self._nbrcommands<=self._batched_cmds:
+		 self._logger.info("processed %i commands. Done.", self._batched_cmds)
+		 sys.exit(0)
+	
+	#get transcribtion - either using audio or text
+	transcribed = self.transcribe_batchcommand(self.passive_stt_engine)
+	if transcribed:		
+		print "YOU: " + " ".join(transcribed)
+
+	#check for keyword	
+	if transcribed and any([self._keyword.lower() in t.lower() for t in transcribed if t]):
+		self._logger.info("Keyword %s has been uttered", self._keyword)
+		return self.active_listen(timeout=3)	
+	else: return False
+
+    def say(self, phrase, OPTIONS=None):
+        print("JASPER: %s" % phrase)

--- a/jasper/batch_mic.py
+++ b/jasper/batch_mic.py
@@ -24,16 +24,16 @@ class Mic(object):
 
     def transcribe_batchcommand(self, stt_engine):
 
-        #still unprocessed commands?
+        # still unprocessed commands?
         if self._nbrcommands <= self._batched_cmds:
             return False
 
         command = self._batchcommands[self._batched_cmds]
         self._batched_cmds += 1
 
-        #check if command is a filename
+        # check if command is a filename
         if os.path.isfile(command):
-            #let's try open it
+            # let's try open it
             fileid = None
             transcribed = False
             try:
@@ -41,7 +41,7 @@ class Mic(object):
             except IOError:
                 self._logger.error("The file %s does not exist!" % command)
             else:
-                #handle it as mic input
+                # handle it as mic input
                 try:
                     transcribed = stt_engine.transcribe(fileid)
                 except:
@@ -49,7 +49,7 @@ class Mic(object):
                     self._logger.error("Transcription failed!", exc_info=dbg)
 
         else:
-            #handle it as text input
+            # handle it as text input
             transcribed = [command]
 
         return transcribed
@@ -58,7 +58,7 @@ class Mic(object):
         return
 
     def active_listen(self, timeout=3):
-        #get transcribtion - either using audio or text
+        # get transcribtion - either using audio or text
         transcribed = self.transcribe_batchcommand(self.active_stt_engine)
         if transcribed:
             print "YOU: " + " ".join(transcribed)
@@ -71,12 +71,12 @@ class Mic(object):
                               self._batched_cmds)
             sys.exit(0)
 
-        #get transcribtion - either using audio or text
+        # get transcribtion - either using audio or text
         transcribed = self.transcribe_batchcommand(self.passive_stt_engine)
         if transcribed:
             print "YOU: " + " ".join(transcribed)
 
-        #check for keyword
+        # check for keyword
         if transcribed and any([self._keyword.lower() in t.lower()
                                 for t in transcribed if t]):
             self._logger.info("Keyword %s has been uttered", self._keyword)

--- a/jasper/batch_mic.py
+++ b/jasper/batch_mic.py
@@ -1,15 +1,13 @@
 # -*- coding: utf-8 -*-
 """
-Mic class impementation that allows for batch mode operation. Useful for debugging. Unlike with the typical Mic
+A drop-in replacement for the Mic class that allows for batch mode operation. Useful for debugging. Unlike with the typical Mic
 implementation, Jasper processes the given commands in the batchfile.
 """
 import os.path
 import logging
 import sys
-#from . import mic
 
-class Mic(object):  
-    
+class Mic(object):      
 
     def __init__(self, passive_stt_engine, active_stt_engine,
                  batchfilecontent, keyword='JASPER'):
@@ -49,8 +47,9 @@ class Mic(object):
                     		self._logger.error("Transcription failed!", exc_info=dbg)
 				transcribed = False
 	else:
-		#handle it as text input
+		#handle it as text input	
 		transcribed = [command]
+
 
 	return transcribed
 

--- a/jasper/batch_mic.py
+++ b/jasper/batch_mic.py
@@ -1,84 +1,88 @@
 # -*- coding: utf-8 -*-
 """
-A drop-in replacement for the Mic class that allows for batch mode operation. Useful for debugging. Unlike with the typical Mic
-implementation, Jasper processes the given commands in the batchfile.
+A drop-in replacement for the Mic class that allows for batch mode operation.
+Useful for debugging. Unlike with the typical Mic implementation, Jasper
+processes the given commands in the batchfile.
 """
 import os.path
 import logging
 import sys
 
-class Mic(object):      
+
+class Mic(object):
 
     def __init__(self, passive_stt_engine, active_stt_engine,
                  batchfilecontent, keyword='JASPER'):
-	#mic.Mic.__init__(self, input_device, output_device,
-        #         passive_stt_engine, active_stt_engine,
-        #         tts_engine, config, keyword='JASPER')
         self._logger = logging.getLogger(__name__)
-        self._keyword = keyword        
+        self._keyword = keyword
         self.passive_stt_engine = passive_stt_engine
-        self.active_stt_engine = active_stt_engine        
-	self._batchcommands=batchfilecontent
-	self._nbrcommands=len(batchfilecontent)
-	self._batched_cmds=0
+        self.active_stt_engine = active_stt_engine
+        self._batchcommands = batchfilecontent
+        self._nbrcommands = len(batchfilecontent)
+        self._batched_cmds = 0
         return
 
     def transcribe_batchcommand(self, stt_engine):
 
-	#still unprocessed commands?
-	if self._nbrcommands<=self._batched_cmds: return False
+        #still unprocessed commands?
+        if self._nbrcommands <= self._batched_cmds:
+            return False
 
-	command = self._batchcommands[self._batched_cmds]
-	self._batched_cmds += 1
-	#check if command is a filename	
-	if os.path.isfile(command):
-		#let's try open it  
-		fileid = None 		
-		try:
-        		fileid = open(command, "r")
-    		except IOError:
-        		self._logger.error("The file %s does not exist!" % command)   
-		else:
-			#handle it as mic input
-			try:
-                    		transcribed = stt_engine.transcribe(fileid)				
-                	except:
-                    		dbg = (self._logger.getEffectiveLevel() == logging.DEBUG)
-                    		self._logger.error("Transcription failed!", exc_info=dbg)
-				transcribed = False
-	else:
-		#handle it as text input	
-		transcribed = [command]
+        command = self._batchcommands[self._batched_cmds]
+        self._batched_cmds += 1
 
+        #check if command is a filename
+        if os.path.isfile(command):
+            #let's try open it
+            fileid = None
+            transcribed = False
+            try:
+                fileid = open(command, "r")
+            except IOError:
+                self._logger.error("The file %s does not exist!" % command)
+            else:
+                #handle it as mic input
+                try:
+                    transcribed = stt_engine.transcribe(fileid)
+                except:
+                    dbg = (self._logger.getEffectiveLevel() == logging.DEBUG)
+                    self._logger.error("Transcription failed!", exc_info=dbg)
 
-	return transcribed
+        else:
+            #handle it as text input
+            transcribed = [command]
+
+        return transcribed
 
     def wait_for_keyword(self, keyword="JASPER"):
         return
 
     def active_listen(self, timeout=3):
-	#get transcribtion - either using audio or text
-	transcribed = self.transcribe_batchcommand(self.active_stt_engine)
-	if transcribed:			
-		print "YOU: " + " ".join(transcribed)
+        #get transcribtion - either using audio or text
+        transcribed = self.transcribe_batchcommand(self.active_stt_engine)
+        if transcribed:
+            print "YOU: " + " ".join(transcribed)
         return transcribed
 
     def listen(self):
-	#still unprocessed commands?
-	if self._nbrcommands<=self._batched_cmds:
-		 self._logger.info("processed %i commands. Done.", self._batched_cmds)
-		 sys.exit(0)
-	
-	#get transcribtion - either using audio or text
-	transcribed = self.transcribe_batchcommand(self.passive_stt_engine)
-	if transcribed:		
-		print "YOU: " + " ".join(transcribed)
+        #still unprocessed commands?
+        if self._nbrcommands <= self._batched_cmds:
+            self._logger.info("processed %i commands. Done.",
+                              self._batched_cmds)
+            sys.exit(0)
 
-	#check for keyword	
-	if transcribed and any([self._keyword.lower() in t.lower() for t in transcribed if t]):
-		self._logger.info("Keyword %s has been uttered", self._keyword)
-		return self.active_listen(timeout=3)	
-	else: return False
+        #get transcribtion - either using audio or text
+        transcribed = self.transcribe_batchcommand(self.passive_stt_engine)
+        if transcribed:
+            print "YOU: " + " ".join(transcribed)
+
+        #check for keyword
+        if transcribed and any([self._keyword.lower() in t.lower()
+                                for t in transcribed if t]):
+            self._logger.info("Keyword %s has been uttered", self._keyword)
+            return self.active_listen(timeout=3)
+        else:
+                return False
 
     def say(self, phrase, OPTIONS=None):
         print("JASPER: %s" % phrase)

--- a/jasper/batch_mic.py
+++ b/jasper/batch_mic.py
@@ -65,7 +65,7 @@ class Mic(object):
         return transcribed
 
     def listen(self):
-        #still unprocessed commands?
+        # still unprocessed commands?
         if self._nbrcommands <= self._batched_cmds:
             self._logger.info("processed %i commands. Done.",
                               self._batched_cmds)

--- a/jasper/mic.py
+++ b/jasper/mic.py
@@ -8,9 +8,9 @@ import contextlib
 import threading
 import math
 import sys
-if sys.version_info < (3, 0):# NOQA
+if sys.version_info < (3, 0):  # NOQA
     import Queue as queue
-else:# NOQA
+else:  # NOQA
     import queue
 from . import alteration
 from . import paths

--- a/jasper/mic.py
+++ b/jasper/mic.py
@@ -12,7 +12,6 @@ if sys.version_info < (3, 0):
     import Queue as queue
 else:
     import queue
-
 from . import alteration
 from . import paths
 

--- a/jasper/mic.py
+++ b/jasper/mic.py
@@ -8,9 +8,9 @@ import contextlib
 import threading
 import math
 import sys
-if sys.version_info < (3, 0):
+if sys.version_info < (3, 0):# NOQA
     import Queue as queue
-else:
+else:# NOQA
     import queue
 from . import alteration
 from . import paths

--- a/jasper/pluginstore.py
+++ b/jasper/pluginstore.py
@@ -4,9 +4,9 @@ import logging
 import imp
 import inspect
 import sys
-if sys.version_info < (3, 0): # NOQA
+if sys.version_info < (3, 0):  # NOQA
     import ConfigParser as configparser
-else:			# NOQA
+else:  # NOQA
     import configparser
 from . import i18n
 from . import plugin

--- a/jasper/pluginstore.py
+++ b/jasper/pluginstore.py
@@ -4,9 +4,9 @@ import logging
 import imp
 import inspect
 import sys
-if sys.version_info < (3, 0):
+if sys.version_info < (3, 0): # NOQA
     import ConfigParser as configparser
-else:
+else:			# NOQA
     import configparser
 from . import i18n
 from . import plugin

--- a/jasper/pluginstore.py
+++ b/jasper/pluginstore.py
@@ -8,7 +8,6 @@ if sys.version_info < (3, 0):
     import ConfigParser as configparser
 else:
     import configparser
-
 from . import i18n
 from . import plugin
 


### PR DESCRIPTION
**Rationale**
currently its not possible to run jasper with a given set of audio files or commands for debugging and automated testing

**Changes**
I added a batch-mode for Jasper (jasper-dev) giving the possibility to run consecutive commands given one per line in a text input file. Commands can be phrases or filenames of audio files. Jasper quits once all commands are processed.

Implementation is done via a drop-in replacement of the mic-class - similar to the "local"-Mode. 

Each line in the batch file is checked whether its a valid existing file - otherwise its assumed to be a text phrase. Keyword needs to provided and is processed with passive-stt, while the phrase is transcribed with active-stt (in case of audio input). Output is always text.

**Sample Batchfile**
A batch file can look like this (comments with #, utf-8 encoding is expected):

`# -*- coding: utf-8 -*-`
`Jasper`
`Testaudio.wav`


**Usage**
call jasper with `--batch filename` option 

PS: actually mic as class name is a bit confusing because its responsible for input and output handling.