### PR TITLE
fixed flake8 error E402

### DIFF
--- a/jasper/mic.py
+++ b/jasper/mic.py
@@ -8,9 +8,9 @@ import contextlib
 import threading
 import math
 import sys
-if sys.version_info < (3, 0):
+if sys.version_info < (3, 0):  # NOQA
     import Queue as queue
-else:
+else:  # NOQA
     import queue
 
 from . import alteration

--- a/jasper/pluginstore.py
+++ b/jasper/pluginstore.py
@@ -4,9 +4,9 @@ import logging
 import imp
 import inspect
 import sys
-if sys.version_info < (3, 0):
+if sys.version_info < (3, 0):  # NOQA
     import ConfigParser as configparser
-else:
+else:  # NOQA
     import configparser
 
 from . import i18n


### PR DESCRIPTION
travis build check fails because of flake8 E402. Fixed it with single line suppression. 

E402 is "module level import not at top of file" - it looks like the problem is a `if` statement necessary due to some renaming in python 3. 