### PR TITLE
Default 4 syllable keyword HelloJasper works much better for new users

### DIFF
--- a/jasper/application.py
+++ b/jasper/application.py
@@ -107,7 +107,9 @@ class Jasper(object):
         try:
             keyword = self.config['keyword']
         except KeyError:
-            keyword = 'Jasper'
+            keyword = 'HelloJasper' # 3-4 syllables works best for new users 
+                                    # who forget 'keyword' in ~/.jasper/profile.yml
+                                    # And all one word works best.
         self._logger.info("Using keyword '%s'", keyword)
 
         # Load plugins


### PR DESCRIPTION
This is my first ever contribution to open source, so please be kind? - I have lots of ideas... ;-) 

**What**: The change is very simple: the default keyword in application.py is changed from "Jasper" to "HelloJasper" which I have found is far more reliable.

**Why**: I have found lots of people struggling with Jasper not recognising the keyword, and I guess some may just give up on it, which would be a pity after they got so far.

I have created the following and posted it in various places in the hope that people will understand the use of the keyword:
[https://github.com/GeoBeBee/mySystem/blob/master/Jasper_keywords.txt](https://github.com/GeoBeBee/mySystem/blob/master/Jasper_keywords.txt)

As a **next change** I might update jasper-client/client/populate.py to set the keyword..? 

Keeping this forking, committing, pushing, branching simple to start with... ;-p
Thanks, Geoff