### PR TITLE
jasper-dev: witai-stt language support

### DIFF
--- a/plugins/stt/witai-stt/witai.py
+++ b/plugins/stt/witai-stt/witai.py
@@ -20,6 +20,9 @@ class WitAiSTTPlugin(plugin.STTPlugin):
     """
 
     def __init__(self, *args, **kwargs):
+    """
+    Create Plugin Instance
+    """
         plugin.STTPlugin.__init__(self, *args, **kwargs)
         self._logger = logging.getLogger(__name__)
         self.token = self.profile['witai-stt']['access_token']
@@ -33,14 +36,23 @@ class WitAiSTTPlugin(plugin.STTPlugin):
 
     @property
     def token(self):
+    """
+    Return defined acess token.
+    """
         return self._token
 
     @property
     def language(self):
+    """
+    Returns selected language
+    """
         return self._language
 
     @token.setter
     def token(self, value):
+    """
+    Sets property token
+    """
         self._token = value
         self._headers = {'Authorization': 'Bearer %s' % self.token,
                          'accept': 'application/json',
@@ -48,9 +60,17 @@ class WitAiSTTPlugin(plugin.STTPlugin):
 
     @property
     def headers(self):
+    """
+    Return headers
+    """
         return self._headers
 
+
     def transcribe(self, fp):
+    """
+    transcribes given audio file by uploading to wit.ai and returning
+    received text from json answer.
+    """
         data = fp.read()
         r = requests.post('https://api.wit.ai/speech?v=20150101',
                           data=data,

--- a/plugins/stt/witai-stt/witai.py
+++ b/plugins/stt/witai-stt/witai.py
@@ -2,6 +2,8 @@ import logging
 import requests
 from jasper import plugin
 
+#there seems to be no way to get language setting of the defined app
+SUPPORTED_LANG=["de", "en", "es", "et", "fr", "it", "nl", "pl", "pt", "ru", "sv"] # last updated 06.04.16
 
 class WitAiSTTPlugin(plugin.STTPlugin):
     """
@@ -14,7 +16,7 @@ class WitAiSTTPlugin(plugin.STTPlugin):
         ...
         stt_engine: witai-stt
         witai-stt:
-          access_token:    ERJKGE86SOMERANDOMTOKEN23471AB
+        access_token:    ERJKGE86SOMERANDOMTOKEN23471AB
     """
 
     def __init__(self, *args, **kwargs):
@@ -26,12 +28,16 @@ class WitAiSTTPlugin(plugin.STTPlugin):
             language = self.profile['language']
         except KeyError:
             language = 'en-US'
-        if language.split('-')[0] != 'en':
-            raise ValueError("Languages other than English are not supported")
+        if language.split('-')[0] not in SUPPORTED_LANG:
+            raise ValueError("Language %s is not supported.",language.split('-')[0])
 
     @property
     def token(self):
         return self._token
+
+    @property
+    def language(self):
+        return self._language
 
     @token.setter
     def token(self, value):


### PR DESCRIPTION
witai-stt is currently only usable with English language setting, due to a language check. Thus witai already supports various different languages this pull request allows more languages.

I haven't found a way to retrieve the language of the defined witai app or a string of support languages, thus the check is done against a hardcoded definition.