### PR TITLE
jasper-dev: sphinx-stt: added support for phonetisaurus version 1.0

### DIFF
--- a/plugins/stt/pocketsphinx-stt/g2p.py
+++ b/plugins/stt/pocketsphinx-stt/g2p.py
@@ -17,10 +17,10 @@ RE_ISYMNOTFOUND = re.compile(r'^Symbol: \'(?P<symbol>.+)\' not found in ' +
 
 def execute(executable, version,  fst_model, input, is_file=False, nbest=None):
     logger = logging.getLogger(__name__)
-    
+   
     cmd = [executable,
                '--model=%s' % fst_model]
-    if version <= 0.8:   
+    if version <= 0.8:
         cmd.append('--input=%s' % input)
         cmd.append('--words')
         if is_file:
@@ -29,7 +29,7 @@ def execute(executable, version,  fst_model, input, is_file=False, nbest=None):
         if is_file:
             cmd.append('--wordlist=%s' % input)
         else:
-            cmd.append('--word=%s' % input)                
+            cmd.append('--word=%s' % input)
 
     if nbest is not None:
         cmd.extend(['--nbest=%d' % nbest])

--- a/plugins/stt/pocketsphinx-stt/g2p.py
+++ b/plugins/stt/pocketsphinx-stt/g2p.py
@@ -15,16 +15,21 @@ RE_ISYMNOTFOUND = re.compile(r'^Symbol: \'(?P<symbol>.+)\' not found in ' +
                              r'input symbols table')
 
 
-def execute(executable, fst_model, input, is_file=False, nbest=None):
+def execute(executable, version,  fst_model, input, is_file=False, nbest=None):
     logger = logging.getLogger(__name__)
-
+    
     cmd = [executable,
-           '--model=%s' % fst_model,
-           '--input=%s' % input,
-           '--words']
-
-    if is_file:
-        cmd.append('--isfile')
+               '--model=%s' % fst_model]
+    if version <= 0.8:   
+        cmd.append('--input=%s' % input)
+        cmd.append('--words')
+        if is_file:
+            cmd.append('--isfile')   
+    else:        
+        if is_file:
+            cmd.append('--wordlist=%s' % input)
+        else:
+            cmd.append('--word=%s' % input)                
 
     if nbest is not None:
         cmd.extend(['--nbest=%d' % nbest])
@@ -74,12 +79,13 @@ def execute(executable, fst_model, input, is_file=False, nbest=None):
 
 
 class PhonetisaurusG2P(object):
-    def __init__(self, executable, fst_model,
+    def __init__(self, executable, version,  fst_model,
                  fst_model_alphabet='arpabet',
                  nbest=None):
         self._logger = logging.getLogger(__name__)
 
         self.executable = executable
+        self.version = version
 
         self.fst_model = os.path.abspath(fst_model)
         self._logger.debug("Using FST model: '%s'", self.fst_model)
@@ -107,7 +113,7 @@ class PhonetisaurusG2P(object):
         raise ValueError('Invalid FST model alphabet!')
 
     def _translate_word(self, word):
-        return execute(self.executable, self.fst_model, word,
+        return execute(self.executable, self.version,  self.fst_model, word,
                        nbest=self.nbest)
 
     def _translate_words(self, words):
@@ -118,7 +124,7 @@ class PhonetisaurusG2P(object):
             for word in words:
                 f.write("%s\n" % word)
             tmp_fname = f.name
-        output = execute(self.executable, self.fst_model, tmp_fname,
+        output = execute(self.executable, self.version,  self.fst_model, tmp_fname,
                          is_file=True, nbest=self.nbest)
         os.remove(tmp_fname)
         return output

--- a/plugins/stt/pocketsphinx-stt/sphinxvocab.py
+++ b/plugins/stt/pocketsphinx-stt/sphinxvocab.py
@@ -45,6 +45,11 @@ def compile_vocabulary(config, directory, phrases):
         executable = 'phonetisaurus-g2p'
 
     try:
+        version = config['pocketsphinx']['phonetisaurus_version']
+    except KeyError:
+        version = 1.0
+
+    try:
         nbest = config['pocketsphinx']['nbest']
     except KeyError:
         nbest = 3
@@ -65,7 +70,7 @@ def compile_vocabulary(config, directory, phrases):
     if not os.path.exists(fst_model):
         raise OSError('FST model does not exist!')
 
-    g2pconverter = PhonetisaurusG2P(executable, fst_model,
+    g2pconverter = PhonetisaurusG2P(executable, version, fst_model,
                                     fst_model_alphabet=fst_model_alphabet,
                                     nbest=nbest)
 

--- a/plugins/stt/pocketsphinx-stt/tests/test_g2p.py
+++ b/plugins/stt/pocketsphinx-stt/tests/test_g2p.py
@@ -30,7 +30,7 @@ class DummyProc(object):
 
 class TestPatchedG2P(unittest.TestCase):
     def setUp(self):
-        self.g2pconv = g2p.PhonetisaurusG2P('dummy_proc', 'dummy_fst_model',
+        self.g2pconv = g2p.PhonetisaurusG2P('dummy_proc', 1.0, 'dummy_fst_model',
                                             nbest=3)
 
     def testTranslateWord(self):


### PR DESCRIPTION
The sphinx-stt uses phonetisaurus. It seems that Phonetisaurus changed its api (option names) from version 0.7.8 to 1.0.

added an option:

`phonetisaurus_version`

for pocketsphinx which determines the correct option names when calling phonetisaurus.  
If nothing is given, Phoentisaurus Version is 1.0 assumed. (which changes the current behaviour)
