### PR TITLE
jasper-dev: text-to-intent mapping

### DIFF
--- a/jasper/application.py
+++ b/jasper/application.py
@@ -105,9 +105,17 @@ class Jasper(object):
             tts_slug = self.config['tts_engine']
         except KeyError:
             tts_slug = 'espeak-tts'
-            self._logger.warning("tts_engine not specified in profile, using" +
+            self._logger.warning("tts_engine not specified in profile, using " +
                                  "defaults.")
         self._logger.debug("Using TTS engine '%s'", tts_slug)
+
+        try:
+            tti_slug = self.config['tti_engine']
+        except KeyError:
+            tti_slug = 'phrasematcher-tti'
+            self._logger.warning("tti_engine not specified in profile, using " +
+                                 "defaults.")
+        self._logger.debug("Using TTI engine '%s'", tti_slug)
 
         try:
             keyword = self.config['keyword']
@@ -213,6 +221,9 @@ class Jasper(object):
 
         tts_plugin_info = self.plugins.get_plugin(tts_slug, category='tts')
         tts_plugin = tts_plugin_info.plugin_class(tts_plugin_info, self.config)
+
+	tti_plugin_info = self.plugins.get_plugin(tti_slug, category='tti')
+        tti_plugin = tti_plugin_info.plugin_class(tti_plugin_info, self.config)
 
         # Initialize Mic
         if use_mic == USE_TEXT_MIC:

--- a/jasper/brain.py
+++ b/jasper/brain.py
@@ -4,17 +4,19 @@ from . import paths
 
 
 class Brain(object):
-    def __init__(self, config):
+    def __init__(self, config, tti_plugin):
         """
         Instantiates a new Brain object, which cross-references user
-        input with a list of modules. Note that the order of brain.modules
-        matters, as the Brain will return the first module
+        input with a list of modules. Note that the order of brain.plugins
+        matters, as the Brain will return the first plugin
         that accepts a given input.
         """
 
         self._plugins = []
         self._logger = logging.getLogger(__name__)
         self._config = config
+        self._tti_plugin = tti_plugin
+        #self._tti = tti_plugin_info.plugin_class(tti_plugin_info, self._config)
 
     def add_plugin(self, plugin):
         self._plugins.append(plugin)

--- a/jasper/plugin.py
+++ b/jasper/plugin.py
@@ -51,6 +51,26 @@ class SpeechHandlerPlugin(GenericPlugin, i18n.GettextMixin):
     def get_priority(self):
         return 0
 
+class TTIPlugin(GenericPlugin):
+    """
+    Generic parent class for text-to-intent handler
+    """
+    __metaclass__ = abc.ABCMeta
+    ACTIONS = []
+    WORDS = {}
+
+    def __init__(self, name, phrases, *args, **kwargs):
+        GenericPlugin.__init__(self, *args, **kwargs)
+
+    @classmethod
+    @abc.abstractmethod	
+    def get_possible_phrases(cls):
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def handle(cls, phrase):
+        pass
 
 class STTPlugin(GenericPlugin):
     def __init__(self, name, phrases, *args, **kwargs):

--- a/jasper/pluginstore.py
+++ b/jasper/pluginstore.py
@@ -141,7 +141,8 @@ class PluginStore(object):
             'audioengine': plugin.AudioEnginePlugin,
             'speechhandler': plugin.SpeechHandlerPlugin,
             'tts': plugin.TTSPlugin,
-            'stt': plugin.STTPlugin
+            'stt': plugin.STTPlugin,
+            'tti': plugin.TTIPlugin
         }
 
     def detect_plugins(self):

--- a/jasper/testutils.py
+++ b/jasper/testutils.py
@@ -12,6 +12,11 @@ TEST_PROFILE = {
 }
 
 
+class TestTTI(object):
+    def __init__(self):
+        pass
+
+
 class TestMic(object):
     def __init__(self, inputs=[]):
         self.inputs = inputs
@@ -31,12 +36,16 @@ class TestMic(object):
         self.outputs.append(phrase)
 
 
-def get_plugin_instance(plugin_class, *extra_args):
+def get_genericplugin_instance(plugin_class, *extra_args):
     info = type('', (object,), {
         'name': 'pluginunittest',
         'translations': {
             'en-US': gettext.NullTranslations()
             }
         })()
-    args = tuple(extra_args) + (info, TEST_PROFILE)
+    args = (info, TEST_PROFILE)+tuple(extra_args)
     return plugin_class(*args)
+
+
+def get_plugin_instance(plugin_class, *extra_args):
+    return get_genericplugin_instance(plugin_class, TestTTI(), TestMic())

--- a/plugins/speechhandler/clock/clock.py
+++ b/plugins/speechhandler/clock/clock.py
@@ -7,6 +7,10 @@ from jasper import plugin
 class ClockPlugin(plugin.SpeechHandlerPlugin):
     def get_phrases(self):
         return [self.gettext("TIME")]
+        
+    def init(self):
+        SpeechHandlerPlugin.init(self)
+        self._tti.ACTIONS = [('WHAT TIME IS IT',self.say_time)]
 
     def handle(self, text, mic):
         """
@@ -24,6 +28,23 @@ class ClockPlugin(plugin.SpeechHandlerPlugin):
         else:
             fmt = "It is {t:%l}:{t.minute} {t:%P} right now."
         mic.say(self.gettext(fmt).format(t=now))
+
+    def say_time(self):
+        """
+        Reports the current time based on the user's timezone.
+
+        Arguments:
+        text -- user-input, typically transcribed speech
+        mic -- used to interact with the user (for both input and output)
+        """
+
+        tz = app_utils.get_timezone(self.profile)
+        now = datetime.datetime.now(tz=tz)
+        if now.minute == 0:
+            fmt = "It is {t:%l} {t:%P} right now."
+        else:
+            fmt = "It is {t:%l}:{t.minute} {t:%P} right now."
+        mic.say(self.gettext(fmt).format(t=now))        
 
     def is_valid(self, text):
         """

--- a/plugins/stt/julius-stt/julius.py
+++ b/plugins/stt/julius-stt/julius.py
@@ -24,6 +24,10 @@ class JuliusSTTPlugin(plugin.STTPlugin):
         self._logger.warning("This STT plugin doesn't have multilanguage " +
                              "support!")
 
+
+    def init(self, *args, **kwargs):
+        plugin.STTPlugin.init(self, *args, **kwargs)
+        
         vocabulary_path = self.compile_vocabulary(
           juliusvocab.compile_vocabulary)
 

--- a/plugins/stt/pocketsphinx-stt/sphinxplugin.py
+++ b/plugins/stt/pocketsphinx-stt/sphinxplugin.py
@@ -40,6 +40,9 @@ class PocketsphinxSTTPlugin(plugin.STTPlugin):
         self._logger.warning("This STT plugin doesn't have multilanguage " +
                              "support!")
 
+    def init(self, *args, **kwargs):
+        plugin.STTPlugin.init(self, *args, **kwargs)
+        
         vocabulary_path = self.compile_vocabulary(
             sphinxvocab.compile_vocabulary)
 

--- a/plugins/stt/pocketsphinx-stt/tests/test_sphinxplugin.py
+++ b/plugins/stt/pocketsphinx-stt/tests/test_sphinxplugin.py
@@ -12,12 +12,12 @@ class TestPocketsphinxSTTPlugin(unittest.TestCase):
         self.time_clip = paths.data('audio', 'time.wav')
 
         try:
-            self.passive_stt_engine = testutils.get_plugin_instance(
-                sphinxplugin.PocketsphinxSTTPlugin,
-                'unittest-passive', ['JASPER'])
-            self.active_stt_engine = testutils.get_plugin_instance(
-                sphinxplugin.PocketSphinxSTTPlugin,
-                'unittest-active', ['TIME'])
+            self.passive_stt_engine = testutils.get_genericplugin_instance(
+                sphinxplugin.PocketsphinxSTTPlugin)
+            self.passive_stt_engine.init('unittest-passive', ['JASPER'])
+            self.active_stt_engine = testutils.get_genericplugin_instance(
+                sphinxplugin.PocketSphinxSTTPlugin)
+            self.active_stt_engine.init('unittest-active', ['TIME'])
         except ImportError:
             self.skipTest("Pockersphinx not installed!")
 

--- a/plugins/tti/phrasematcher-tti/__init__.py
+++ b/plugins/tti/phrasematcher-tti/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from .phrasematcher import PhraseMatcherPlugin

--- a/plugins/tti/phrasematcher-tti/phrasematcher.py
+++ b/plugins/tti/phrasematcher-tti/phrasematcher.py
@@ -1,0 +1,106 @@
+#implementation taken from https://gist.github.com/Holzhaus/cdf3e9534e6295d40e07
+import itertools
+import string
+import re
+from jasper import plugin
+
+class PhraseMatcherPlugin(plugin.TTIPlugin):
+
+    @classmethod
+    def get_possible_phrases(cls):
+        # Sample implementation, there might be a better one
+        phrases = []
+        for base_phrase, action in cls.ACTIONS:
+            placeholders = [x[1] for x in string.Formatter().parse(base_phrase)]
+            factors = [placeholder_values[placeholder] for placeholder in placeholders]
+            combinations = itertools.product(*factors)
+            for combination in combinations:
+                replacement_values = dict(zip(placeholders,combination))
+                phrases.append(base_phrase.format(**replacement_values))
+        return phrases
+
+    @classmethod
+    def get_regex_phrases(cls):
+        return [cls.base_phrase_to_regex_pattern(base_phrase) for base_phrase, action in cls.ACTIONS]
+
+    @classmethod
+    def base_phrase_to_regex_pattern(cls, base_phrase):
+        # Sample implementation, I think that this can be improved, too
+        placeholders = [x[1] for x in string.Formatter().parse(base_phrase)]
+        placeholder_values = {}
+        for placeholder in placeholders:
+            placeholder_values[placeholder] = '(?P<{}>.+)'.format(placeholder)
+        regex_phrase = "^{}$".format(base_phrase.format(**placeholder_values))
+        pattern = re.compile(regex_phrase, re.LOCALE | re.UNICODE)
+        return pattern
+
+    @classmethod
+    def match_phrase(cls, phrase):
+        for pattern in cls.get_regex_phrases():
+            matchobj = pattern.match(phrase)
+            if matchobj:
+                return matchobj
+        return None
+
+    @classmethod
+    def handle_intent(cls, phrase):
+        matchobj = cls.match_phrase(phrase)
+        if matchobj:
+            for base_phrase, action in cls.ACTIONS:
+                if matchobj.re.match(base_phrase):
+                    kwargs = matchobj.groupdict()
+                    action(**kwargs)
+                    return True
+        return False
+
+#
+# Now we create 2 classes that inhert from Phrase Matcher and actually define some phrases/actions
+#
+#
+#class LightController(PhraseMatcher):
+#    @classmethod
+#    def change_light_color(cls, **kwargs):
+#        print("Changing {location} light colors  to {color} now...".format(**kwargs))
+#    @classmethod
+#    def switch_light_state(cls, **kwargs):
+#        print("Switching lights {state} now...".format(**kwargs))
+#    WORDS = {'location': ['ALL', 'BEDROOM', 'LIVINGROOM','BATHROOM'],
+#             'color': ['BLUE','YELLOW','RED', 'GREEN'],
+#             'state': ['ON','OFF']}
+# Hack because we can't reference classmethods inside the class definition
+#LightController.ACTIONS = [('SWITCH {location} LIGHTS TO COLOR {color}', LightController.change_light_color),
+#                           ('SWITCH LIGHTS {state}', LightController.switch_light_state)]#
+#
+#import time
+#class Clock(PhraseMatcher):
+#    @classmethod
+#    def say_time(cls, **kwargs):
+#        print(time.strftime("The time is %H hours and %M minutes."))
+#Clock.ACTIONS = [('WHAT TIME IS IT',Clock.say_time)]#
+#
+#
+# Here we define the classes that are going to handle input phrases
+#
+#
+#PLUGINS = [LightController, Clock]#
+#
+#def handle(phrase):
+#    handled = False
+#    for plugin in PLUGINS:
+#        if plugin.handle(phrase):
+#            handled = True
+#    if not handled:
+#        print("No plugin can handle: '{}'".format(phrase))
+#    return handled
+
+#
+# Some sample input
+#
+
+#sample_phrases = ["SWITCH LIVINGROOM LIGHTS TO COLOR RED",
+#                  "WHAT TIME IS IT",
+#                  "THIS IS A TEST PHRASE NO PLUGIN UNDERSTANDS",
+#                  "SWITCH LIGHTS OFF"]
+#
+#for phrase in sample_phrases:
+#    handle(phrase)

--- a/plugins/tti/phrasematcher-tti/phrasematcher.py
+++ b/plugins/tti/phrasematcher-tti/phrasematcher.py
@@ -1,4 +1,4 @@
-#implementation taken from https://gist.github.com/Holzhaus/cdf3e9534e6295d40e07
+#basic implementation taken from https://gist.github.com/Holzhaus/cdf3e9534e6295d40e07
 import itertools
 import string
 import re
@@ -6,11 +6,10 @@ from jasper import plugin
 
 class PhraseMatcherPlugin(plugin.TTIPlugin):
 
-    @classmethod
-    def get_possible_phrases(cls):
+    def get_phrases(self):
         # Sample implementation, there might be a better one
         phrases = []
-        for base_phrase, action in cls.ACTIONS:
+        for base_phrase, action in self.ACTIONS:
             placeholders = [x[1] for x in string.Formatter().parse(base_phrase)]
             factors = [placeholder_values[placeholder] for placeholder in placeholders]
             combinations = itertools.product(*factors)
@@ -19,12 +18,10 @@ class PhraseMatcherPlugin(plugin.TTIPlugin):
                 phrases.append(base_phrase.format(**replacement_values))
         return phrases
 
-    @classmethod
-    def get_regex_phrases(cls):
-        return [cls.base_phrase_to_regex_pattern(base_phrase) for base_phrase, action in cls.ACTIONS]
+    def get_regex_phrases(self):
+        return [self.base_phrase_to_regex_pattern(base_phrase) for base_phrase, action in self.ACTIONS]
 
-    @classmethod
-    def base_phrase_to_regex_pattern(cls, base_phrase):
+    def base_phrase_to_regex_pattern(self, base_phrase):
         # Sample implementation, I think that this can be improved, too
         placeholders = [x[1] for x in string.Formatter().parse(base_phrase)]
         placeholder_values = {}
@@ -34,73 +31,41 @@ class PhraseMatcherPlugin(plugin.TTIPlugin):
         pattern = re.compile(regex_phrase, re.LOCALE | re.UNICODE)
         return pattern
 
-    @classmethod
-    def match_phrase(cls, phrase):
-        for pattern in cls.get_regex_phrases():
+    def match_phrase(self, phrase):
+        for pattern in self.get_regex_phrases():
             matchobj = pattern.match(phrase)
             if matchobj:
                 return matchobj
         return None
 
-    @classmethod
-    def handle_intent(cls, phrase):
-        matchobj = cls.match_phrase(phrase)
+    def is_valid(self, phrase):
+        matchobj = self.match_phrase(phrase)
         if matchobj:
-            for base_phrase, action in cls.ACTIONS:
+            return True
+        return False
+
+    def get_confidence(self, phrase):
+        return is_valid(self, phrase)
+
+    def get_actionlist(self, phrase):
+        pass
+
+    def get_intent(self, phrase):
+        matchobj = self.match_phrase(phrase)
+        if matchobj:
+            for base_phrase, action in self.ACTIONS:
                 if matchobj.re.match(base_phrase):
                     kwargs = matchobj.groupdict()
+                    #action(**kwargs)                   
+                    return [action, kwargs]
+        return [None,  None]
+
+    def handle_intent(self, phrase):
+        matchobj = self.match_phrase(phrase)
+        if matchobj:
+            for base_phrase, action in self.ACTIONS:
+                if matchobj.re.match(base_phrase):
+                    kwargs = matchobj.groupdict()                    
                     action(**kwargs)
                     return True
         return False
-
-#
-# Now we create 2 classes that inhert from Phrase Matcher and actually define some phrases/actions
-#
-#
-#class LightController(PhraseMatcher):
-#    @classmethod
-#    def change_light_color(cls, **kwargs):
-#        print("Changing {location} light colors  to {color} now...".format(**kwargs))
-#    @classmethod
-#    def switch_light_state(cls, **kwargs):
-#        print("Switching lights {state} now...".format(**kwargs))
-#    WORDS = {'location': ['ALL', 'BEDROOM', 'LIVINGROOM','BATHROOM'],
-#             'color': ['BLUE','YELLOW','RED', 'GREEN'],
-#             'state': ['ON','OFF']}
-# Hack because we can't reference classmethods inside the class definition
-#LightController.ACTIONS = [('SWITCH {location} LIGHTS TO COLOR {color}', LightController.change_light_color),
-#                           ('SWITCH LIGHTS {state}', LightController.switch_light_state)]#
-#
-#import time
-#class Clock(PhraseMatcher):
-#    @classmethod
-#    def say_time(cls, **kwargs):
-#        print(time.strftime("The time is %H hours and %M minutes."))
-#Clock.ACTIONS = [('WHAT TIME IS IT',Clock.say_time)]#
-#
-#
-# Here we define the classes that are going to handle input phrases
-#
-#
-#PLUGINS = [LightController, Clock]#
-#
-#def handle(phrase):
-#    handled = False
-#    for plugin in PLUGINS:
-#        if plugin.handle(phrase):
-#            handled = True
-#    if not handled:
-#        print("No plugin can handle: '{}'".format(phrase))
-#    return handled
-
-#
-# Some sample input
-#
-
-#sample_phrases = ["SWITCH LIVINGROOM LIGHTS TO COLOR RED",
-#                  "WHAT TIME IS IT",
-#                  "THIS IS A TEST PHRASE NO PLUGIN UNDERSTANDS",
-#                  "SWITCH LIGHTS OFF"]
-#
-#for phrase in sample_phrases:
-#    handle(phrase)

--- a/plugins/tti/phrasematcher-tti/plugin.info
+++ b/plugins/tti/phrasematcher-tti/plugin.info
@@ -1,0 +1,10 @@
+[Plugin]
+Name = phrasematcher-tti
+Version = 1.0.0
+License = MIT
+URL = http://jasperproject.github.io/
+Description = Text-to-intent matching which relies on phrase matching using regex.
+
+[Author]
+Name = Jasper Project
+URL = http://jasperproject.github.io/

--- a/plugins/tti/phrasematcher-tti/test_phrasematcher.py
+++ b/plugins/tti/phrasematcher-tti/test_phrasematcher.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+import unittest
+import time
+from jasper import testutils
+from . import phrasematcher
+
+#
+# Some sample input
+#
+
+sample_phrases = [("LightController",  "SWITCH LIVINGROOM LIGHTS TO COLOR RED"),
+                                ("Clock", "WHAT TIME IS IT"),
+                                ("None", "THIS IS A TEST PHRASE NO PLUGIN UNDERSTANDS"),
+                                ("LightController", "SWITCH LIGHTS OFF")]
+
+class LightController():
+    
+    def __init__(self, mic):
+        self._mic = mic
+        self._tti=testutils.get_genericplugin_instance(phrasematcher.PhraseMatcherPlugin)
+        self._tti.WORDS = {'location': ['ALL', 'BEDROOM', 'LIVINGROOM','BATHROOM'],
+                                        'color': ['BLUE','YELLOW','RED', 'GREEN'],
+                                        'state': ['ON','OFF']}
+        self._tti.ACTIONS = [('SWITCH {location} LIGHTS TO COLOR {color}', LightController.change_light_color),
+                                        ('SWITCH LIGHTS {state}', LightController.switch_light_state)]
+
+    def change_light_color(self, **kwargs):
+        self._mic.say("Changing {location} light colors  to {color} now...".format(**kwargs))
+
+    def switch_light_state(self, **kwargs):
+        self._mic.say("Switching lights {state} now...".format(**kwargs))
+        
+    def handle(self, phrase):
+        action, param = self._tti.get_intent(phrase)
+        if action:
+            action(self, **param)
+        
+    def is_valid(self, phrase):
+        self._tti.is_valid(phrase)        
+        
+    def name(self):
+        return "LightController"
+
+class Clock():
+   
+    def __init__(self,  mic):
+        self._mic = mic
+        self._tti=testutils.get_genericplugin_instance(phrasematcher.PhraseMatcherPlugin)
+        self._tti.ACTIONS = [('WHAT TIME IS IT',Clock.say_time)]#
+
+    def say_time(self, **kwargs):
+        self._mic.say(time.strftime("The time is %H hours and %M minutes."))
+        
+    def handle(self, phrase):
+        action, param = self._tti.get_intent(phrase)
+        if action:
+            action(self, **param)
+        
+    def is_valid(self, phrase):
+        self._tti.is_valid(phrase)    
+
+    def name(self):
+        return "Clock"        
+
+class TestPhrasematcherPlugin(unittest.TestCase):
+    def setUp(self):
+        self.mic = testutils.TestMic()
+        self.plugins = [LightController(self.mic), Clock(self.mic)]   
+   
+    def handle(self, phrase):
+        handled = False
+        for plugin in self.plugins:
+            if plugin.handle(phrase):
+                handled = True        
+        return handled   
+
+    def test_is_valid_method(self): 
+        for plugin in self.plugins:    
+            for pluginname,  phrase in sample_phrases:
+                if pluginname == plugin.name:
+                    self.assertTrue(plugin.is_valid(phrase))
+                else:
+                     self.assertFalse(plugin.is_valid(phrase))
+
+    def test_handle_method(self):        
+        for pluginname,  phrase in sample_phrases:
+            self.handle(phrase) 
+        self.assertEqual(len(self.mic.outputs), 3)
+        #print self.mic.outputs

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -24,8 +24,8 @@ class ExamplePlugin(object):
 
 class TestBrain(unittest.TestCase):
     def testPriority(self):
-        """Does Brain sort modules by priority?"""
-        my_brain = brain.Brain(testutils.TEST_PROFILE)
+        """Does Brain sort modules by priority?"""        
+        my_brain = brain.Brain(testutils.TEST_PROFILE, ExamplePlugin(['MOCK_TTI']))
 
         plugin1 = ExamplePlugin(['MOCK1'], priority=1)
         plugin2 = ExamplePlugin(['MOCK1'], priority=999)
@@ -52,7 +52,7 @@ class TestBrain(unittest.TestCase):
     def testPluginPhraseExtraction(self):
         expected_phrases = ['MOCK1', 'MOCK2']
 
-        my_brain = brain.Brain(testutils.TEST_PROFILE)
+        my_brain = brain.Brain(testutils.TEST_PROFILE,  ExamplePlugin(['MOCK_TTI']))
 
         my_brain.add_plugin(ExamplePlugin(['MOCK2']))
         my_brain.add_plugin(ExamplePlugin(['MOCK1']))
@@ -64,7 +64,7 @@ class TestBrain(unittest.TestCase):
     def testStandardPhraseExtraction(self):
         expected_phrases = ['MOCK']
 
-        my_brain = brain.Brain(testutils.TEST_PROFILE)
+        my_brain = brain.Brain(testutils.TEST_PROFILE,  ExamplePlugin(['MOCK_TTI']))
 
         with tempfile.TemporaryFile() as f:
             # We can't use mock_open here, because it doesn't seem to work


### PR DESCRIPTION
I've picked up the discussion from #504 and #361 with the implementation from 
#134. Here's a first implementation intented for discussion.

**Rationale**

Jasper currently leaves it to the speechhandling plugins how they are extracting the intent from the phrase or keywords. Most plugins just use simple keyword searching. To improve Jasper this should be more sophisticated or at least be able to improve later one. Currently this is blocked because each plugins implements its own way and thus it can only be improved by improving the plugins. 

I created a new plugin class named TTI (text-to-intent)-Mapping. The idea is to return from a given text what the user wanted to do. Thus making the "speechhandling plugins" to "action_plugins" implementing various actions linked to an intent definition. And the TTI as a translator between the transcribed text and the action.

This decouples the recognition of what the user wanted from the plugins, making this more generic and giving the possibility to improve this later on. 

**Changes**

So far, basically I integrated the Phrasematcher from #134 into a plugin and made it available for the speechhandler plugins.

I created a new plugin class with intent that there might be other kinds of matching implementations later on and (with a config system for plugins) that plugin may choose which TTI they use.

I needed to divide the initialization of STT-Plugins into two steps to be able to pass mic and TTI to the speechhandling plugins during instance creation.

**Example**

Its the sample from #134: Have a look at test_phrasematcher.py. 



Is this a way Jasper wants to go? I'm open for ideas, suggestions and discussion.
