### PR TITLE
jasper-dev: Added mad to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ python-slugify==0.1.0
 pytz==2014.10
 PyYAML==3.11
 requests==2.5.0
+mad=0.2.2
 
 # Pocketsphinx STT engine
 cmuclmtk==0.1.5


### PR DESCRIPTION
Current mad is not in the requirements.txt file. I don't know what the correct version number is but I added the current one.