### PR TITLE
Fixed typo in pocketsphynx unittest

### DIFF
--- a/plugins/stt/pocketsphinx-stt/tests/test_sphinxplugin.py
+++ b/plugins/stt/pocketsphinx-stt/tests/test_sphinxplugin.py
@@ -16,7 +16,7 @@ class TestPocketsphinxSTTPlugin(unittest.TestCase):
                 sphinxplugin.PocketsphinxSTTPlugin,
                 'unittest-passive', ['JASPER'])
             self.active_stt_engine = testutils.get_plugin_instance(
-                sphinxplugin.PocketSphinxSTTPlugin,
+                sphinxplugin.PocketsphinxSTTPlugin,
                 'unittest-active', ['TIME'])
         except ImportError:
             self.skipTest("Pockersphinx not installed!")


### PR DESCRIPTION
`PocketsphinxSTTPlugin `is being referenced as `PocketSphinxSTTPlugin`, causing the unittest to fail.