### PR TITLE
Convert input to 16kHz if necessary

### DIFF
--- a/jasper/mic.py
+++ b/jasper/mic.py
@@ -8,6 +8,7 @@ import contextlib
 import threading
 import math
 import sys
+
 if sys.version_info < (3, 0):  # NOQA
     import Queue as queue
 else:  # NOQA
@@ -103,8 +104,17 @@ class Mic(object):
             wav_fp = wave.open(f, 'wb')
             wav_fp.setnchannels(self._input_channels)
             wav_fp.setsampwidth(int(self._input_bits/8))
-            wav_fp.setframerate(self._input_rate)
-            wav_fp.writeframes(''.join(frames))
+            wav_fp.setframerate(16000)
+            if self._input_rate == 16000:
+                wav_fp.writeframes(''.join(frames))
+            else:
+                wav_fp.writeframes(audioop.ratecv(''.join(frames),
+                                                  int(self._input_bits/8),
+                                                  self._input_channels,
+                                                  self._input_rate,
+                                                  16000,
+                                                  None)
+                                   [0])
             wav_fp.close()
             f.seek(0)
             yield f


### PR DESCRIPTION
Since the provided language models of cmusphinx are for 16kHz, it does not make sense to use input at another sampling rate. However, setting the recording rat to 16kHz fixed is not an option, because not all microphones support 16kHz recording.
With this fix the recording is converted to 16kHz if it is not already at 16kHz.