### PR TITLE
Default version of Wit API now changed to 20160526

### DIFF
--- a/plugins/stt/witai-stt/witai.py
+++ b/plugins/stt/witai-stt/witai.py
@@ -86,7 +86,7 @@ class WitAiSTTPlugin(plugin.STTPlugin):
         received text from json answer.
         """
         data = fp.read()
-        r = requests.post('https://api.wit.ai/speech?v=20150101',
+        r = requests.post('https://api.wit.ai/speech?v=20160526',
                           data=data,
                           headers=self.headers)
         try:


### PR DESCRIPTION
Default version of Wit API now changed to 20160526.
https://wit.ai/docs/http/20160526#post--speech-link