### PR TITLE
Add output_chunksize as input parameter for play_fp

### DIFF
--- a/jasper/mic.py
+++ b/jasper/mic.py
@@ -228,7 +228,7 @@ class Mic(object):
         with tempfile.SpooledTemporaryFile() as f:
             f.write(self.tts_engine.say(altered_phrase))
             f.seek(0)
-            self._output_device.play_fp(f)
+            self._output_device.play_fp(f, self._output_chunksize)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
play_fp always uses default chunksize(1200) even
output_chunksize is configurable.

Signed-off-by: Zhiyi Sun <zhiyisun@gmail.com>