### PR TITLE
Update marytts.py

### DIFF
--- a/plugins/tts/mary-tts/marytts.py
+++ b/plugins/tts/mary-tts/marytts.py
@@ -93,7 +93,7 @@ class MaryTTSPlugin(plugin.TTSPlugin):
         query = {'OUTPUT_TYPE': 'AUDIO',
                  'AUDIO': 'WAVE_FILE',
                  'INPUT_TYPE': 'TEXT',
-                 'INPUT_TEXT': phrase,
+                 'INPUT_TEXT': phrase.encode('utf8'),
                  'LOCALE': self.language,
                  'VOICE': self.voice}
 


### PR DESCRIPTION
INPUT_TEXT can contain unicode-characters which urllib.urlencode might not like and result in an error. Therefore encoding the phrase beforehand. More information in issue #644 