### PR TITLE
Add IBM Watson support

### DIFF
--- a/client/conversation.py
+++ b/client/conversation.py
@@ -114,6 +114,8 @@ class Conversation(object):
                                self.persona)
             threshold, transcribed = self.mic.passiveListen(self.persona)
             found = (transcribed + [''])[0]
+            if 'AMOS' not in found: continue
+
             if 'BOUNCE' in found or 'BALANCE' in found:
                 print("BOUNCEING...")
                 bounce()

--- a/client/conversation.py
+++ b/client/conversation.py
@@ -3,6 +3,90 @@ import logging
 from notifier import Notifier
 from brain import Brain
 
+from subprocess import Popen, PIPE
+
+def bounce():
+    scpt = '''
+        tell application "Logic Pro X" to activate
+        delay 1
+        tell application "System Events"
+          keystroke "b" using command down
+          delay 1
+          keystroke return
+        end tell
+        '''
+    args = []
+
+    p = Popen(['osascript', '-'] + args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    stdout, stderr = p.communicate(scpt)
+    print (p.returncode, stdout, stderr)
+
+def record():
+    scpt = '''
+        tell application "Logic Pro X" to activate
+        delay 1
+        tell application "System Events"
+          keystroke "r"
+        end tell
+        '''
+    args = []
+
+    p = Popen(['osascript', '-'] + args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    stdout, stderr = p.communicate(scpt)
+    print (p.returncode, stdout, stderr)
+
+def stop_req():
+    scpt = '''
+        tell application "Logic Pro X" to activate
+        delay 1
+        tell application "System Events"
+          key code 49
+        end tell
+        '''
+    args = []
+
+    p = Popen(['osascript', '-'] + args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    stdout, stderr = p.communicate(scpt)
+    print (p.returncode, stdout, stderr)
+
+def copy_track():
+    scpt = '''
+        tell application "Logic Pro X" to activate
+        delay 1
+        tell application "System Events"
+          keystroke "d" using command down
+        end tell
+        '''
+    args = []
+
+    p = Popen(['osascript', '-'] + args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    stdout, stderr = p.communicate(scpt)
+    print (p.returncode, stdout, stderr)
+
+def bring_begin():
+    scpt = '''
+        tell application "System Events"
+          keystroke return
+        end tell
+        '''
+    args = []
+
+    p = Popen(['osascript', '-'] + args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    stdout, stderr = p.communicate(scpt)
+    print (p.returncode, stdout, stderr)
+
+def confirm():
+    scpt = '''
+        tell application "System Events"
+          keystroke return
+        end tell
+        '''
+    args = []
+
+    p = Popen(['osascript', '-'] + args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    stdout, stderr = p.communicate(scpt)
+    print (p.returncode, stdout, stderr)
+
 
 class Conversation(object):
 
@@ -29,6 +113,26 @@ class Conversation(object):
             self._logger.debug("Started listening for keyword '%s'",
                                self.persona)
             threshold, transcribed = self.mic.passiveListen(self.persona)
+            found = (transcribed + [''])[0]
+            if 'BOUNCE' in found or 'BALANCE' in found:
+                print("BOUNCEING...")
+                bounce()
+            if 'REC' in found or 'RECORD' in found or 'START' in found:
+                print("RECORDING...")
+                record()
+            if 'STOP' in found or 'END' in found:
+                print("STOPPING...")
+                stop_req()
+            if 'DUPLICATE' in found or 'COPY' in found:
+                print("COPYING...")
+                copy_track()
+            if 'FRONT' in found or 'BEGINING' in found or 'FRONT' in found:
+                print("BRINGING BEGIN...")
+                bring_begin()
+            if 'CONFIRM' in found or 'YES' in found or 'ENTER' in found or 'CONTINUE' in found:
+                print("CONFIRMING...")
+                confirm()
+
             self._logger.debug("Stopped listening for keyword '%s'",
                                self.persona)
 

--- a/client/diagnose.py
+++ b/client/diagnose.py
@@ -6,7 +6,6 @@ import socket
 import subprocess
 import pkgutil
 import logging
-import pip.req
 import jasperpath
 if sys.version_info < (3, 3):
     from distutils.spawn import find_executable
@@ -89,6 +88,12 @@ def check_python_import(package_or_module):
     return found
 
 
+def parse_requirements(filename):
+    """ load requirements from a pip requirements file """
+    lineiter = (line.strip() for line in open(filename))
+    return [line for line in lineiter if line and not line.startswith("#")]
+
+
 def get_pip_requirements(fname=os.path.join(jasperpath.LIB_PATH,
                                             'requirements.txt')):
     """
@@ -104,7 +109,7 @@ def get_pip_requirements(fname=os.path.join(jasperpath.LIB_PATH,
     """
     logger = logging.getLogger(__name__)
     if os.access(fname, os.R_OK):
-        reqs = list(pip.req.parse_requirements(fname))
+        reqs = list(parse_requirements(fname))
         logger.debug("Found %d PIP requirements in file '%s'", len(reqs),
                      fname)
         return reqs

--- a/run.command
+++ b/run.command
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Hello"
+
+# /usr/bin/python /Users/zoe/Developer/jasper-client/jasper.py

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "hello"
+
+cd /Users/zoe/Developer/jasper-client
+
+/usr/bin/python /Users/zoe/Developer/jasper-client/jasper.py


### PR DESCRIPTION
# Watson Support
This commit adds support for the IBM Watson STT API which is very fast and accurate. I modeled it very closely after the wit.ai implementation.

### Disclamer!
> Test every commit on a Raspberry Pi. Testing locally (i.e., on OS X or Windows or whatnot) is insufficient, as you'll often run into semi-unpredictable issues when you port over to the Pi. You should both run the unit tests described above and do some anecdotal testing (i.e., run Jasper, trigger at least one module).

This **has not** been tested on a Raspberry Pi. I do not have a Raspberry Pi, but I thought I would make a PR anyway incase someone else wanted to test it on their Raspberry Pi for me.