### PR TITLE
Fix: critical Bad request error from Wit.ai and Update: api url

### DIFF
--- a/client/stt.py
+++ b/client/stt.py
@@ -594,9 +594,14 @@ class WitAiSTT(AbstractSTTEngine):
             r.raise_for_status()
             text = r.json()['_text']
         except requests.exceptions.HTTPError:
-            self._logger.critical('Request failed with response: %r',
-                                  r.text,
-                                  exc_info=True)
+            if r.json()['error'] == 'Bad request':
+                self._logger.debug('Request failed with response: %r',
+                                      r.text)
+                self._logger.info('Response: Failed to parse')
+            else:
+                self._logger.critical('Request failed with response: %r',
+                                      r.text,
+                                      exc_info=True)
             return []
         except requests.exceptions.RequestException:
             self._logger.critical('Request failed.', exc_info=True)


### PR DESCRIPTION
When Wit.ai STT gets something it cannot parse into text it returns `400 Bad request`. This is presented as a critical error when it does not need to be. This critical error is making people abandon jasper after getting so far.

This PR also updates the API version. 

### Issues this PR will fix
- #655
- #648
- #650 

### Question
- [ ] With this PR, jasper logs `'Response: Failed to parse'`. Should this be a warning? Should it not log anything?